### PR TITLE
Generify constraints in linear real arithmetic

### DIFF
--- a/src/main/java/me/paultristanwagner/satchecking/parse/LinearConstraintLexer.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/LinearConstraintLexer.java
@@ -7,7 +7,15 @@ public class LinearConstraintLexer extends Lexer {
   public LinearConstraintLexer(String input) {
     super(input);
 
-    registerTokenTypes(MIN, MAX, FRACTION, DECIMAL, IDENTIFIER, EQUALS, LOWER_EQUALS, GREATER_EQUALS, PLUS, MINUS, LPAREN, RPAREN);
+    registerTokenTypes(
+        MIN,
+        MAX,
+        EQUALS,
+        LOWER_EQUALS,
+        GREATER_EQUALS,
+        LPAREN,
+        RPAREN
+    );
 
     initialize(input);
   }

--- a/src/main/java/me/paultristanwagner/satchecking/parse/LinearConstraintParser.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/LinearConstraintParser.java
@@ -1,9 +1,13 @@
 package me.paultristanwagner.satchecking.parse;
 
 import me.paultristanwagner.satchecking.theory.LinearConstraint;
+import me.paultristanwagner.satchecking.theory.LinearConstraint.Bound;
 import me.paultristanwagner.satchecking.theory.LinearConstraint.MaximizingConstraint;
 import me.paultristanwagner.satchecking.theory.LinearConstraint.MinimizingConstraint;
+import me.paultristanwagner.satchecking.theory.LinearTerm;
 import me.paultristanwagner.satchecking.theory.arithmetic.Number;
+
+import java.util.Scanner;
 
 import static me.paultristanwagner.satchecking.parse.TokenType.*;
 import static me.paultristanwagner.satchecking.theory.LinearConstraint.Bound.*;
@@ -11,21 +15,29 @@ import static me.paultristanwagner.satchecking.theory.arithmetic.Number.ONE;
 
 public class LinearConstraintParser implements Parser<LinearConstraint> {
 
+  public static void main(String[] args) {
+    LinearConstraintParser parser = new LinearConstraintParser();
+
+    Scanner scanner = new Scanner(System.in);
+    String line;
+    while ((line = scanner.nextLine()) != null) {
+      try {
+        LinearConstraint constraint = parser.parse(line);
+        System.out.println(constraint);
+      } catch (SyntaxError e) {
+        e.printWithContext();
+        e.printStackTrace();
+      }
+    }
+  }
+
   /*
    *  Grammar for Linear constraints:
-   *    <S> ::= <TERM> '=' <RATIONAL>
-   *          | <TERM> '<=' <RATIONAL>
-   *          | <TERM> '>=' <RATIONAL>
+   *    <S> ::= <TERM> '=' <TERM>
+   *          | <TERM> '<=' <TERM
+   *          | <TERM> '>=' <TERM>
    *          | MIN '(' <TERM> ')'
    *          | MAX '(' <TERM> ')'
-   *
-   *    <TERM> ::= [ <SIGNS> ] [ <RATIONAL> ] IDENTIFIER
-   *             | [ <SIGNS> ] [ <RATIONAL> ] IDENTIFIER [ <SIGNS> <TERM> ]
-   *
-   *    <SIGNS> ::= '+' [ <SIGNS> ]
-   *              | '-' [ <SIGNS> ]
-   *
-   *    <RATIONAL> ::= FRACTION | DECIMAL
    *
    */
   @Override
@@ -34,128 +46,63 @@ public class LinearConstraintParser implements Parser<LinearConstraint> {
 
     lexer.requireNextToken();
 
-    LinearConstraint lc = TERM(lexer);
+    boolean optimization = false;
+    boolean minimization = false;
+
+    if (lexer.canConsume(MIN)) {
+      lexer.consume(MIN);
+      lexer.consume(LPAREN);
+
+      optimization = true;
+      minimization = true;
+    } else if (lexer.canConsume(MAX)) {
+      lexer.consume(MAX);
+      lexer.consume(LPAREN);
+
+      optimization = true;
+    }
+
+    LinearTerm lhs = TERM(lexer);
+
+    LinearConstraint lc;
+    if(optimization) {
+      if(minimization) {
+        lc = new MinimizingConstraint(lhs);
+      } else {
+        lc = new MaximizingConstraint(lhs);
+      }
+
+      lexer.consume(RPAREN);
+      return new ParseResult<>(lc, lexer.getCursor(), lexer.getCursor() == string.length());
+    }
+
+    Bound bound = BOUND(lexer);
+
+    LinearTerm rhs = TERM(lexer);
+
+    lc = new LinearConstraint(lhs, rhs, bound);
 
     return new ParseResult<>(lc, lexer.getCursor(), lexer.getCursor() == string.length());
   }
 
-  private static LinearConstraint TERM(Lexer lexer) {
-    LinearConstraint lc;
-    boolean optimization = false;
+  private static LinearTerm TERM(Lexer lexer) {
+    LinearTermParser parser = new LinearTermParser();
+    ParseResult<LinearTerm> result = parser.parseWithRemaining(lexer.getRemaining());
 
-    if (lexer.canConsume(MIN)) {
-      optimization = true;
-      lexer.consume(MIN);
+    return result.result();
+  }
 
-      lexer.consume(LPAREN);
-      lc = new MinimizingConstraint();
-    } else if (lexer.canConsume(MAX)) {
-      optimization = true;
-      lexer.consume(MAX);
-
-      lexer.consume(LPAREN);
-      lc = new MaximizingConstraint();
-    } else {
-      lc = new LinearConstraint();
-    }
-
-    Number coefficient = OPTIONAL_SIGNS(lexer).multiply(OPTIONAL_RATIONAL(lexer));
-    Token variableToken = lexer.getLookahead();
-    lexer.consume(IDENTIFIER);
-    String variable = variableToken.getValue();
-    lc.setCoefficient(variable, coefficient);
-
-    while (lexer.canConsumeEither(PLUS, MINUS, FRACTION, DECIMAL)) {
-      coefficient = OPTIONAL_SIGNS(lexer).multiply(OPTIONAL_RATIONAL(lexer));
-      variableToken = lexer.getLookahead();
-
-      lexer.consume(IDENTIFIER);
-
-      variable = variableToken.getValue();
-      lc.setCoefficient(variable, coefficient);
-    }
-
-    if (optimization) {
-      lexer.consume(RPAREN);
-      return lc;
-    }
-
+  private static Bound BOUND(Lexer lexer) {
     lexer.requireEither(EQUALS, LOWER_EQUALS, GREATER_EQUALS);
     if (lexer.canConsume(EQUALS)) {
       lexer.consume(EQUALS);
-      lc.setBound(EQUAL);
+      return EQUAL;
     } else if (lexer.canConsume(LOWER_EQUALS)) {
       lexer.consume(LOWER_EQUALS);
-      lc.setBound(UPPER);
+      return UPPER;
     } else {
       lexer.consume(GREATER_EQUALS);
-      lc.setBound(LOWER);
+      return LOWER;
     }
-
-    Number value = OPTIONAL_SIGNS(lexer).multiply(RATIONAL(lexer));
-    lc.setValue(value);
-
-    return lc;
-  }
-
-  private static Number OPTIONAL_SIGNS(Lexer lexer) {
-    if (lexer.canConsumeEither(PLUS, MINUS)) {
-      return SIGNS(lexer);
-    } else {
-      return ONE();
-    }
-  }
-
-  private static Number SIGNS(Lexer lexer) {
-    lexer.requireEither(PLUS, MINUS);
-
-    Number sign = ONE();
-    do {
-      if (lexer.canConsume(PLUS)) {
-        lexer.consume(PLUS);
-      } else {
-        lexer.consume(MINUS);
-        sign = sign.negate();
-      }
-    } while (lexer.canConsumeEither(PLUS, MINUS));
-
-    return sign;
-  }
-
-  private static Number OPTIONAL_RATIONAL(Lexer lexer) {
-    if (lexer.canConsumeEither(FRACTION, DECIMAL)) {
-      return RATIONAL(lexer);
-    }
-
-    return ONE();
-  }
-
-  private static Number RATIONAL(Lexer lexer) {
-    lexer.requireEither(FRACTION, DECIMAL);
-
-    if (lexer.canConsume(FRACTION)) {
-      return FRACTION(lexer);
-    } else {
-      return DECIMAL(lexer);
-    }
-  }
-
-  private static Number DECIMAL(Lexer lexer) {
-    Token token = lexer.getLookahead();
-    lexer.consume(DECIMAL);
-
-    return Number.parse(token.getValue());
-  }
-
-  private static Number FRACTION(Lexer lexer) {
-    Token token = lexer.getLookahead();
-    lexer.consume(FRACTION);
-
-    String[] parts = token.getValue().split("/");
-
-    long numerator = Long.parseLong(parts[0]);
-    long denominator = Long.parseLong(parts[1]);
-
-    return Number.number(numerator, denominator);
   }
 }

--- a/src/main/java/me/paultristanwagner/satchecking/parse/LinearConstraintParser.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/LinearConstraintParser.java
@@ -5,13 +5,12 @@ import me.paultristanwagner.satchecking.theory.LinearConstraint.Bound;
 import me.paultristanwagner.satchecking.theory.LinearConstraint.MaximizingConstraint;
 import me.paultristanwagner.satchecking.theory.LinearConstraint.MinimizingConstraint;
 import me.paultristanwagner.satchecking.theory.LinearTerm;
-import me.paultristanwagner.satchecking.theory.arithmetic.Number;
 
 import java.util.Scanner;
 
 import static me.paultristanwagner.satchecking.parse.TokenType.*;
+import static me.paultristanwagner.satchecking.parse.TokenType.GREATER_EQUALS;
 import static me.paultristanwagner.satchecking.theory.LinearConstraint.Bound.*;
-import static me.paultristanwagner.satchecking.theory.arithmetic.Number.ONE;
 
 public class LinearConstraintParser implements Parser<LinearConstraint> {
 
@@ -24,6 +23,10 @@ public class LinearConstraintParser implements Parser<LinearConstraint> {
       try {
         LinearConstraint constraint = parser.parse(line);
         System.out.println(constraint);
+        System.out.println("lhs = " + constraint.getLeftHandSide());
+        System.out.println("rhs = " + constraint.getRightHandSide());
+        System.out.println("bound = " + constraint.getBound());
+        System.out.println("lhs - rhs = " + constraint.getDifference());
       } catch (SyntaxError e) {
         e.printWithContext();
         e.printStackTrace();
@@ -43,8 +46,6 @@ public class LinearConstraintParser implements Parser<LinearConstraint> {
   @Override
   public ParseResult<LinearConstraint> parseWithRemaining(String string) {
     Lexer lexer = new LinearConstraintLexer(string);
-
-    lexer.requireNextToken();
 
     boolean optimization = false;
     boolean minimization = false;
@@ -89,6 +90,8 @@ public class LinearConstraintParser implements Parser<LinearConstraint> {
     LinearTermParser parser = new LinearTermParser();
     ParseResult<LinearTerm> result = parser.parseWithRemaining(lexer.getRemaining());
 
+    lexer.skip(result.charsRead());
+
     return result.result();
   }
 
@@ -99,10 +102,10 @@ public class LinearConstraintParser implements Parser<LinearConstraint> {
       return EQUAL;
     } else if (lexer.canConsume(LOWER_EQUALS)) {
       lexer.consume(LOWER_EQUALS);
-      return UPPER;
+      return LESS_EQUALS;
     } else {
       lexer.consume(GREATER_EQUALS);
-      return LOWER;
+      return Bound.GREATER_EQUALS;
     }
   }
 }

--- a/src/main/java/me/paultristanwagner/satchecking/parse/LinearTermLexer.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/LinearTermLexer.java
@@ -1,0 +1,20 @@
+package me.paultristanwagner.satchecking.parse;
+
+import static me.paultristanwagner.satchecking.parse.TokenType.*;
+
+public class LinearTermLexer extends Lexer {
+
+  public LinearTermLexer(String input) {
+    super(input);
+
+    registerTokenTypes(
+        FRACTION,
+        DECIMAL,
+        IDENTIFIER,
+        PLUS,
+        MINUS
+    );
+
+    initialize(input);
+  }
+}

--- a/src/main/java/me/paultristanwagner/satchecking/parse/LinearTermLexer.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/LinearTermLexer.java
@@ -8,11 +8,11 @@ public class LinearTermLexer extends Lexer {
     super(input);
 
     registerTokenTypes(
+        PLUS,
+        MINUS,
         FRACTION,
         DECIMAL,
-        IDENTIFIER,
-        PLUS,
-        MINUS
+        IDENTIFIER
     );
 
     initialize(input);

--- a/src/main/java/me/paultristanwagner/satchecking/parse/LinearTermParser.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/LinearTermParser.java
@@ -1,0 +1,126 @@
+package me.paultristanwagner.satchecking.parse;
+
+import me.paultristanwagner.satchecking.theory.LinearTerm;
+import me.paultristanwagner.satchecking.theory.arithmetic.Number;
+
+import static me.paultristanwagner.satchecking.parse.TokenType.*;
+import static me.paultristanwagner.satchecking.theory.arithmetic.Number.ONE;
+
+public class LinearTermParser implements Parser<LinearTerm> {
+
+  /*
+   * Grammar for linear terms:
+   *   <TERM> ::= [ <SIGNS> ] [ <RATIONAL> ] IDENTIFIER [ <SIGNS> <TERM> ]
+   *            | [ <SIGNS> ] <RATIONAL> [ <SIGNS> <TERM> ]
+   *
+   */
+
+  @Override
+  public ParseResult<LinearTerm> parseWithRemaining(String string) {
+    LinearTermLexer lexer = new LinearTermLexer(string);
+
+    lexer.requireNextToken();
+
+    LinearTerm term = new LinearTerm();
+
+    Number value = OPTIONAL_SIGNS(lexer);
+    boolean explicitValue = false;
+
+    if(lexer.canConsumeEither(DECIMAL, FRACTION)) {
+      explicitValue = true;
+      value = value.multiply(OPTIONAL_RATIONAL(lexer));
+    }
+
+    if(!explicitValue) {
+      lexer.require(IDENTIFIER);
+      String identifier = lexer.getLookahead().getValue();
+      lexer.consume(IDENTIFIER);
+      term.addCoefficient(identifier, value);
+    } else {
+      term.addConstant(value);
+    }
+
+    while(lexer.canConsumeEither(PLUS, MINUS)) {
+      Number sign = SIGNS(lexer);
+      value = OPTIONAL_SIGNS(lexer);
+      explicitValue = false;
+
+      if(lexer.canConsumeEither(DECIMAL, FRACTION)) {
+        explicitValue = true;
+        value = value.multiply(OPTIONAL_RATIONAL(lexer));
+      }
+
+      if(!explicitValue) {
+        lexer.require(IDENTIFIER);
+        String identifier = lexer.getLookahead().getValue();
+        lexer.consume(IDENTIFIER);
+        term.addCoefficient(identifier, sign.multiply(value));
+      } else {
+        term.addConstant(sign.multiply(value));
+      }
+    }
+
+    return new ParseResult<>(term, lexer.getCursor(), lexer.getRemaining().isEmpty());
+  }
+
+  private static Number OPTIONAL_SIGNS(Lexer lexer) {
+    if (lexer.canConsumeEither(PLUS, MINUS)) {
+      return SIGNS(lexer);
+    } else {
+      return ONE();
+    }
+  }
+
+  private static Number SIGNS(Lexer lexer) {
+    lexer.requireEither(PLUS, MINUS);
+
+    Number sign = ONE();
+    do {
+      if (lexer.canConsume(PLUS)) {
+        lexer.consume(PLUS);
+      } else {
+        lexer.consume(MINUS);
+        sign = sign.negate();
+      }
+    } while (lexer.canConsumeEither(PLUS, MINUS));
+
+    return sign;
+  }
+
+  private static Number OPTIONAL_RATIONAL(Lexer lexer) {
+    if (lexer.canConsumeEither(FRACTION, DECIMAL)) {
+      return RATIONAL(lexer);
+    }
+
+    return ONE();
+  }
+
+  private static Number RATIONAL(Lexer lexer) {
+    lexer.requireEither(FRACTION, DECIMAL);
+
+    if (lexer.canConsume(FRACTION)) {
+      return FRACTION(lexer);
+    } else {
+      return DECIMAL(lexer);
+    }
+  }
+
+  private static Number DECIMAL(Lexer lexer) {
+    Token token = lexer.getLookahead();
+    lexer.consume(DECIMAL);
+
+    return Number.parse(token.getValue());
+  }
+
+  private static Number FRACTION(Lexer lexer) {
+    Token token = lexer.getLookahead();
+    lexer.consume(FRACTION);
+
+    String[] parts = token.getValue().split("/");
+
+    long numerator = Long.parseLong(parts[0]);
+    long denominator = Long.parseLong(parts[1]);
+
+    return Number.number(numerator, denominator);
+  }
+}

--- a/src/main/java/me/paultristanwagner/satchecking/parse/LinearTermParser.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/LinearTermParser.java
@@ -31,7 +31,7 @@ public class LinearTermParser implements Parser<LinearTerm> {
       value = value.multiply(OPTIONAL_RATIONAL(lexer));
     }
 
-    if(!explicitValue) {
+    if(!explicitValue || lexer.canConsume(IDENTIFIER)) {
       lexer.require(IDENTIFIER);
       String identifier = lexer.getLookahead().getValue();
       lexer.consume(IDENTIFIER);
@@ -50,7 +50,7 @@ public class LinearTermParser implements Parser<LinearTerm> {
         value = value.multiply(OPTIONAL_RATIONAL(lexer));
       }
 
-      if(!explicitValue) {
+      if(!explicitValue || lexer.canConsume(IDENTIFIER)) {
         lexer.require(IDENTIFIER);
         String identifier = lexer.getLookahead().getValue();
         lexer.consume(IDENTIFIER);

--- a/src/main/java/me/paultristanwagner/satchecking/theory/LinearTerm.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/LinearTerm.java
@@ -1,0 +1,155 @@
+package me.paultristanwagner.satchecking.theory;
+
+import me.paultristanwagner.satchecking.smt.VariableAssignment;
+import me.paultristanwagner.satchecking.theory.arithmetic.Number;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static me.paultristanwagner.satchecking.theory.arithmetic.Number.ZERO;
+
+public class LinearTerm {
+
+  protected final Set<String> variables;
+  protected final Map<String, Number> coefficients;
+  private Number constant;
+
+  public LinearTerm() {
+    this.variables = new HashSet<>();
+    this.coefficients = new HashMap<>();
+    this.constant = ZERO();
+  }
+
+  public LinearTerm(LinearTerm term) {
+    this.variables = new HashSet<>(term.variables);
+    this.coefficients = new HashMap<>(term.coefficients);
+    this.constant = term.constant;
+  }
+
+  public void setCoefficient(String variable, Number coefficient) {
+    variables.add(variable);
+    coefficients.put(variable, coefficient);
+
+    if(coefficients.get(variable).equals(ZERO())) {
+      coefficients.remove(variable);
+      variables.remove(variable);
+    }
+  }
+
+  public void addCoefficient(String variable, Number coefficient) {
+    if (coefficients.containsKey(variable)) {
+      coefficients.put(variable, coefficients.get(variable).add(coefficient));
+    } else {
+      setCoefficient(variable, coefficient);
+    }
+
+    if(coefficients.get(variable).equals(ZERO())) {
+      coefficients.remove(variable);
+      variables.remove(variable);
+    }
+  }
+
+  public Set<String> getVariables() {
+    return variables;
+  }
+
+  public Map<String, Number> getCoefficients() {
+    return coefficients;
+  }
+
+  public Number getConstant() {
+    return constant;
+  }
+
+  public void setConstant(Number constant) {
+    this.constant = constant;
+  }
+
+  public void addConstant(Number value) {
+    this.constant = this.constant.add(value);
+  }
+
+  public LinearTerm add(LinearTerm term) {
+    LinearTerm result = new LinearTerm(this);
+    term.coefficients.forEach(result::addCoefficient);
+    result.addConstant(term.constant);
+    return result;
+  }
+
+  public LinearTerm subtract(LinearTerm term) {
+    LinearTerm result = new LinearTerm(this);
+    term.coefficients.forEach((variable, coefficient) -> result.addCoefficient(variable, coefficient.negate()));
+    result.addConstant(term.constant.negate());
+    return result;
+  }
+
+  public LinearTerm offset(String variable, String substitute, Number offset) {
+    LinearTerm term = new LinearTerm(this);
+    if (!coefficients.containsKey(variable)) {
+      return this;
+    }
+
+    Number coeff = coefficients.get(variable);
+    term.variables.remove(variable);
+    term.coefficients.remove(variable);
+    term.setCoefficient(substitute, coeff);
+
+    term.constant = constant.subtract(
+        coeff.multiply(offset)
+    );
+
+    return term;
+  }
+
+  public LinearTerm positiveNegativeSubstitute(
+      String variable, String positive, String negative) {
+    Number coeff = coefficients.get(variable);
+
+    LinearTerm term = new LinearTerm(this);
+    term.variables.remove(variable);
+    term.coefficients.remove(variable);
+    term.setCoefficient(positive, coeff);
+    term.setCoefficient(negative, coeff.negate());
+
+    return term;
+  }
+
+  public Number evaluate(VariableAssignment<Number> assignment) {
+    Number result = ZERO();
+    for (String variable : variables) {
+      Number summand = coefficients.get(variable).multiply(assignment.getAssignment(variable));
+      result = result.add(summand);
+    }
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    coefficients.forEach(
+        (variable, coefficient) -> {
+          if (coefficient.isNonNegative()) {
+            if (!sb.isEmpty()) {
+              sb.append("+");
+            }
+          } else {
+            sb.append("-");
+          }
+
+          Number absolute = coefficient.abs();
+          if (!absolute.isOne()) {
+            sb.append(absolute);
+          }
+
+          sb.append(variable);
+        });
+
+    if(sb.isEmpty()) {
+      sb.append("0");
+    }
+
+    return sb.toString();
+  }
+}

--- a/src/main/java/me/paultristanwagner/satchecking/theory/LinearTerm.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/LinearTerm.java
@@ -78,11 +78,15 @@ public class LinearTerm {
     return result;
   }
 
-  public LinearTerm subtract(LinearTerm term) {
-    LinearTerm result = new LinearTerm(this);
-    term.coefficients.forEach((variable, coefficient) -> result.addCoefficient(variable, coefficient.negate()));
-    result.addConstant(term.constant.negate());
+  public LinearTerm negate() {
+    LinearTerm result = new LinearTerm();
+    this.coefficients.forEach((variable, coefficient) -> result.addCoefficient(variable, coefficient.negate()));
+    result.addConstant(this.constant.negate());
     return result;
+  }
+
+  public LinearTerm subtract(LinearTerm term) {
+    return this.add(term.negate());
   }
 
   public LinearTerm offset(String variable, String substitute, Number offset) {
@@ -96,7 +100,7 @@ public class LinearTerm {
     term.coefficients.remove(variable);
     term.setCoefficient(substitute, coeff);
 
-    term.constant = constant.subtract(
+    term.constant = constant.add(
         coeff.multiply(offset)
     );
 
@@ -105,6 +109,10 @@ public class LinearTerm {
 
   public LinearTerm positiveNegativeSubstitute(
       String variable, String positive, String negative) {
+    if(!coefficients.containsKey(variable) || coefficients.get(variable).equals(ZERO())) {
+      return this;
+    }
+
     Number coeff = coefficients.get(variable);
 
     LinearTerm term = new LinearTerm(this);
@@ -122,6 +130,7 @@ public class LinearTerm {
       Number summand = coefficients.get(variable).multiply(assignment.getAssignment(variable));
       result = result.add(summand);
     }
+    result = result.add(constant);
     return result;
   }
 
@@ -145,6 +154,18 @@ public class LinearTerm {
 
           sb.append(variable);
         });
+
+    if (!constant.equals(ZERO())) {
+      if (constant.isNonNegative()) {
+        if (!sb.isEmpty()) {
+          sb.append("+");
+        }
+      } else {
+        sb.append("-");
+      }
+
+      sb.append(constant.abs());
+    }
 
     if(sb.isEmpty()) {
       sb.append("0");

--- a/src/main/java/me/paultristanwagner/satchecking/theory/solver/LinearIntegerSolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/solver/LinearIntegerSolver.java
@@ -38,7 +38,7 @@ public class LinearIntegerSolver implements TheorySolver<LinearConstraint> {
 
   @Override
   public TheoryResult<LinearConstraint> solve() {
-    if (depth > MAXIMUM_BRANCH_DEPTH) {
+    /* if (depth > MAXIMUM_BRANCH_DEPTH) {
       return TheoryResult.unknown();
     }
 
@@ -142,6 +142,7 @@ public class LinearIntegerSolver implements TheorySolver<LinearConstraint> {
       return TheoryResult.unknown();
     }
 
-    return TheoryResult.unsatisfiable(constraints);
+    return TheoryResult.unsatisfiable(constraints); */
+    return null;
   }
 }

--- a/src/main/java/me/paultristanwagner/satchecking/theory/solver/SimplexFeasibilitySolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/solver/SimplexFeasibilitySolver.java
@@ -7,6 +7,7 @@ import me.paultristanwagner.satchecking.theory.arithmetic.Number;
 
 import java.util.*;
 
+import static me.paultristanwagner.satchecking.theory.LinearConstraint.Bound.*;
 import static me.paultristanwagner.satchecking.theory.arithmetic.Number.ONE;
 import static me.paultristanwagner.satchecking.theory.arithmetic.Number.ZERO;
 
@@ -70,16 +71,16 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
 
       for (int j = 0; j < variableSet.size(); j++) {
         String variable = variables.get(j);
-        tableau[i][j] = constraint.getCoefficients().getOrDefault(variable, ZERO());
+        tableau[i][j] = constraint.getDifference().getCoefficients().getOrDefault(variable, ZERO());
       }
 
-      if (constraint.getBound() == LinearConstraint.Bound.EQUAL) {
-        lowerBounds.put(slackName, constraint.getValue());
-        upperBounds.put(slackName, constraint.getValue());
-      } else if (constraint.getBound() == LinearConstraint.Bound.UPPER) {
-        upperBounds.put(slackName, constraint.getValue());
-      } else if (constraint.getBound() == LinearConstraint.Bound.LOWER) {
-        lowerBounds.put(slackName, constraint.getValue());
+      if (constraint.getBound() == EQUAL) {
+        lowerBounds.put(slackName, constraint.getDifference().getConstant().negate());
+        upperBounds.put(slackName, constraint.getDifference().getConstant().negate());
+      } else if (constraint.getBound() == LESS_EQUALS) {
+        upperBounds.put(slackName, constraint.getDifference().getConstant().negate());
+      } else if (constraint.getBound() == GREATER_EQUALS) {
+        lowerBounds.put(slackName, constraint.getDifference().getConstant().negate());
       }
     }
 

--- a/src/main/java/me/paultristanwagner/satchecking/theory/solver/SimplexOptimizationSolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/solver/SimplexOptimizationSolver.java
@@ -578,6 +578,7 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
     if (constraint.getBound() == LinearConstraint.Bound.EQUAL) {
       LinearConstraint first = new LinearConstraint();
       LinearConstraint second = new LinearConstraint();
+
       first.setDerivedFrom(constraint);
       second.setDerivedFrom(constraint);
 

--- a/src/main/java/me/paultristanwagner/satchecking/theory/solver/SimplexOptimizationSolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/solver/SimplexOptimizationSolver.java
@@ -1,20 +1,24 @@
 package me.paultristanwagner.satchecking.theory.solver;
 
+import static me.paultristanwagner.satchecking.theory.LinearConstraint.Bound.EQUAL;
+import static me.paultristanwagner.satchecking.theory.LinearConstraint.Bound.LESS_EQUALS;
+import static me.paultristanwagner.satchecking.theory.LinearConstraint.greaterThanOrEqual;
+import static me.paultristanwagner.satchecking.theory.LinearConstraint.lessThanOrEqual;
+import static me.paultristanwagner.satchecking.theory.arithmetic.Number.ONE;
+import static me.paultristanwagner.satchecking.theory.arithmetic.Number.ZERO;
+
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import java.util.*;
+import java.util.Map.Entry;
 import me.paultristanwagner.satchecking.smt.VariableAssignment;
 import me.paultristanwagner.satchecking.theory.LinearConstraint;
 import me.paultristanwagner.satchecking.theory.LinearConstraint.MaximizingConstraint;
 import me.paultristanwagner.satchecking.theory.LinearConstraint.MinimizingConstraint;
+import me.paultristanwagner.satchecking.theory.LinearTerm;
 import me.paultristanwagner.satchecking.theory.SimplexResult;
 import me.paultristanwagner.satchecking.theory.arithmetic.Number;
 import org.apache.commons.lang3.tuple.Pair;
-
-import java.util.*;
-import java.util.Map.Entry;
-
-import static me.paultristanwagner.satchecking.theory.arithmetic.Number.ONE;
-import static me.paultristanwagner.satchecking.theory.arithmetic.Number.ZERO;
 
 public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint> {
 
@@ -34,8 +38,12 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
   private int columns;
   private Number[][] tableau;
 
-  private final List<LinearConstraint> originalConstraints;
+  private List<LinearConstraint> originalConstraints;
   private List<LinearConstraint> constraints;
+
+  private List<LinearTerm> differences;
+  private Map<LinearTerm, LinearConstraint> origin;
+
   private LinearConstraint originalObjective;
   private LinearConstraint objective;
 
@@ -50,6 +58,8 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
 
     this.originalConstraints = new ArrayList<>();
     this.constraints = new ArrayList<>();
+    this.differences = new ArrayList<>();
+    this.origin = new HashMap<>();
 
     this.substitutions = HashBiMap.create();
     this.offsets = new HashMap<>();
@@ -58,7 +68,7 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
   }
 
   public void maximize(LinearConstraint f) {
-    if (!(f instanceof MaximizingConstraint)) {
+    if (!(f instanceof MaximizingConstraint maximizingConstraint)) {
       throw new IllegalArgumentException("The objective function must be a maximizing constraint.");
     }
 
@@ -66,12 +76,12 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
       throw new IllegalStateException("The objective function has already been set.");
     }
 
-    this.originalObjective = f;
-    this.objective = f;
+    this.originalObjective = maximizingConstraint;
+    this.objective = originalObjective;
   }
 
   public void minimize(LinearConstraint f) {
-    if (!(f instanceof MinimizingConstraint)) {
+    if (!(f instanceof MinimizingConstraint minimizingConstraint)) {
       throw new IllegalArgumentException("The objective function must be a minimizing constraint.");
     }
 
@@ -79,12 +89,8 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
       throw new IllegalStateException("The objective function has already been set.");
     }
 
-    this.originalObjective = f;
-    this.objective = new LinearConstraint(f);
-
-    for (String variable : objective.getVariables()) {
-      objective.setCoefficient(variable, objective.getCoefficients().get(variable).negate());
-    }
+    this.originalObjective = minimizingConstraint;
+    this.objective = new MaximizingConstraint(minimizingConstraint.getTerm().negate());
   }
 
   @Override
@@ -99,6 +105,8 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
 
     this.originalConstraints.clear();
     this.constraints.clear();
+    this.origin.clear();
+    this.differences.clear();
 
     this.substitutions.clear();
     this.offsets.clear();
@@ -124,19 +132,18 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
     allVariables.addAll(tempSet);
 
     // Infer bounds
-    Pair<Map<String, LinearConstraint>, Map<String, LinearConstraint>> inferedBounds =
-        inferBounds();
+    Pair<Map<String, LinearConstraint>, Map<String, LinearConstraint>> inferredBounds = inferBounds();
 
-    SimplexResult result = checkBoundsConsistency(inferedBounds);
+    SimplexResult result = checkBoundsConsistency(inferredBounds);
     if (result != null && !result.isFeasible()) {
       return result;
     }
 
     List<String> withoutLowerBounds = new ArrayList<>(allVariables);
-    withoutLowerBounds.removeAll(inferedBounds.getLeft().keySet());
+    withoutLowerBounds.removeAll(inferredBounds.getLeft().keySet());
 
     // Transform constraints, where a single variable has a bound other than zero
-    transformOffsetVariables(inferedBounds);
+    transformOffsetVariables(inferredBounds);
 
     // Replace unbounded variables
     replaceUnboundedVariables(withoutLowerBounds);
@@ -290,28 +297,36 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
       Iterator<LinearConstraint> iterator = constraints.iterator();
       while (iterator.hasNext()) {
         LinearConstraint constraint = iterator.next();
-        if (constraint.getCoefficients().size() != 1) {
+        // only evaluate bounds for constraints over a single variable
+        if (constraint.getVariables().size() != 1) {
           iterator.remove();
           keptConstraints.add(constraint);
           continue;
         }
 
+        // get the variable that is constrained
         String constraintVariable = constraint.getVariables().iterator().next();
         if (!variable.equals(constraintVariable)) continue;
 
+        // the bound on the
         Number bound = constraint.getBoundOn(constraintVariable);
+        boolean isUpperBound =
+            constraint.getBound()
+                == LESS_EQUALS
+                == constraint
+                    .getDifference()
+                    .getCoefficients()
+                    .get(constraintVariable)
+                    .greaterThanOrEqual(ZERO());
 
-        if (constraint.getBound()
-            != LinearConstraint.Bound.UPPER
-            == constraint.getCoefficients().get(constraintVariable).greaterThan(ZERO())) {
-          if (!lowerBounds.containsKey(variable)
-              || lowerBounds.get(variable).getBoundOn(variable).lessThan(ZERO())) {
-            lowerBounds.put(variable, constraint);
+        // tightening bounds
+        if(isUpperBound) {
+          if(!upperBounds.containsKey(constraintVariable) || bound.lessThan(upperBounds.get(constraintVariable).getBoundOn(constraintVariable))) {
+            upperBounds.put(constraintVariable, constraint);
           }
         } else {
-          if (!upperBounds.containsKey(variable)
-              || upperBounds.get(variable).getBoundOn(variable).greaterThan(bound)) {
-            upperBounds.put(variable, constraint);
+          if(!lowerBounds.containsKey(constraintVariable) || bound.greaterThan(lowerBounds.get(constraintVariable).getBoundOn(constraintVariable))) {
+            lowerBounds.put(constraintVariable, constraint);
           }
         }
       }
@@ -374,7 +389,7 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
 
       for (int i = 0; i < constraints.size(); i++) {
         LinearConstraint linearConstraint = constraints.get(i);
-        if (linearConstraint.getCoefficients().containsKey(variable)) {
+        if (linearConstraint.constrainsVariable(variable)) {
           LinearConstraint offsetConstraint = linearConstraint.offset(variable, substitute, bound);
           constraints.set(i, offsetConstraint);
         }
@@ -402,7 +417,7 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
 
       for (int i = 0; i < constraints.size(); i++) {
         LinearConstraint linearConstraint = constraints.get(i);
-        if (linearConstraint.getCoefficients().containsKey(unboundedVariable)) {
+        if (linearConstraint.constrainsVariable(unboundedVariable)) {
           LinearConstraint positiveNegative =
               linearConstraint.positiveNegativeSubstitute(unboundedVariable, positive, negative);
           constraints.set(i, positiveNegative);
@@ -410,7 +425,7 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
       }
 
       if (objective != null) {
-        if (objective.getCoefficients().containsKey(unboundedVariable)) {
+        if(objective.constrainsVariable(unboundedVariable)) {
           objective = objective.positiveNegativeSubstitute(unboundedVariable, positive, negative);
         }
       }
@@ -434,25 +449,26 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
     if (objective != null) {
       for (int i = 0; i < allVariables.size(); i++) {
         String variable = allVariables.get(i);
-        tableau[0][i] = objective.getCoefficients().getOrDefault(variable, ZERO()).negate();
+        // todo: abstract Minimizing and Maximizing Constraint into OptimizingConstraint
+        tableau[0][i] = objective.getLeftHandSide().getCoefficients().getOrDefault(variable, ZERO()).negate();
       }
     }
 
     for (int i = 0; i < constraints.size(); i++) {
       LinearConstraint constraint = constraints.get(i);
 
-      if (constraint.getBound() == LinearConstraint.Bound.LOWER) {
+      if (constraint.getBound() == LinearConstraint.Bound.GREATER_EQUALS) {
         for (int j = 0; j < allVariables.size(); j++) {
           String variable = allVariables.get(j);
-          tableau[i + 1][j] = constraint.getCoefficients().getOrDefault(variable, ZERO()).negate();
+          tableau[i + 1][j] = constraint.getDifference().getCoefficients().getOrDefault(variable, ZERO()).negate();
         }
-        tableau[i + 1][allVariables.size()] = constraint.getValue().negate();
+        tableau[i + 1][allVariables.size()] = constraint.getDifference().getConstant();
       } else {
         for (int j = 0; j < allVariables.size(); j++) {
           String variable = allVariables.get(j);
-          tableau[i + 1][j] = constraint.getCoefficients().getOrDefault(variable, ZERO());
+          tableau[i + 1][j] = constraint.getDifference().getCoefficients().getOrDefault(variable, ZERO());
         }
-        tableau[i + 1][allVariables.size()] = constraint.getValue();
+        tableau[i + 1][allVariables.size()] = constraint.getDifference().getConstant().negate();
       }
       tableau[i + 1][nonBasicVariables.size() + i] = ONE();
     }
@@ -498,7 +514,8 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
   private Number calculateObjectiveValue() {
     Number objectiveValue = ZERO();
 
-    for (Entry<String, Number> pair : originalObjective.getCoefficients().entrySet()) {
+    // todo: also access the optimizing constraint here properly
+    for (Entry<String, Number> pair : originalObjective.getLeftHandSide().getCoefficients().entrySet()) {
       Number value = getValue(pair.getKey());
       objectiveValue = objectiveValue.add(pair.getValue().multiply(value));
     }
@@ -524,10 +541,10 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
       } else {
         String actual = substitutions.inverse().getOrDefault(variable, variable);
         for (LinearConstraint originalConstraint : originalConstraints) {
-          if (originalConstraint.getBound() == LinearConstraint.Bound.UPPER) continue;
+          if (originalConstraint.getBound() == LESS_EQUALS) continue;
           // if (originalConstraint.getCoefficients().size() != 1) continue;
 
-          String onlyVariable = originalConstraint.getCoefficients().keySet().iterator().next();
+          String onlyVariable = originalConstraint.getDifference().getCoefficients().keySet().iterator().next();
           if (onlyVariable.equals(actual)) {
             explanation.add(originalConstraint.getRoot());
           }
@@ -575,25 +592,12 @@ public class SimplexOptimizationSolver implements TheorySolver<LinearConstraint>
       return;
     }
 
-    if (constraint.getBound() == LinearConstraint.Bound.EQUAL) {
-      LinearConstraint first = new LinearConstraint();
-      LinearConstraint second = new LinearConstraint();
+    if (constraint.getBound() == EQUAL) {
+      LinearConstraint first = lessThanOrEqual(constraint.getLeftHandSide(), constraint.getRightHandSide());
+      LinearConstraint second = greaterThanOrEqual(constraint.getLeftHandSide(), constraint.getRightHandSide());
 
       first.setDerivedFrom(constraint);
       second.setDerivedFrom(constraint);
-
-      first.setBound(LinearConstraint.Bound.UPPER);
-      second.setBound(LinearConstraint.Bound.LOWER);
-
-      constraint
-          .getCoefficients()
-          .forEach(
-              (variable, coefficient) -> {
-                first.setCoefficient(variable, coefficient);
-                second.setCoefficient(variable, coefficient);
-              });
-      first.setValue(constraint.getValue());
-      second.setValue(constraint.getValue());
 
       constraints.add(first);
       constraints.add(second);

--- a/src/test/java/LinearConstraintParserTest.java
+++ b/src/test/java/LinearConstraintParserTest.java
@@ -3,6 +3,7 @@ import me.paultristanwagner.satchecking.theory.LinearConstraint;
 import me.paultristanwagner.satchecking.theory.arithmetic.Number;
 import org.junit.jupiter.api.Test;
 
+import static me.paultristanwagner.satchecking.theory.LinearConstraint.Bound.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class LinearConstraintParserTest {
@@ -12,14 +13,20 @@ public class LinearConstraintParserTest {
   @Test
   public void testConstraints() {
     LinearConstraint lc0 = parser.parse("-31.17x+-+-101.0y=-+-27.156");
-    assertEquals(Number.parse("-31.17"), lc0.getCoefficients().get("x"));
-    assertEquals(Number.parse("101"), lc0.getCoefficients().get("y"));
-    assertEquals(Number.parse("27.156"), lc0.getValue());
-    assertEquals(LinearConstraint.Bound.EQUAL, lc0.getBound());
+    assertEquals(Number.parse("-31.17"), lc0.getDifference().getCoefficients().get("x"));
+    assertEquals(Number.parse("101"), lc0.getDifference().getCoefficients().get("y"));
+    assertEquals(Number.parse("-27.156"), lc0.getDifference().getConstant());
+    assertEquals(EQUAL, lc0.getBound());
 
     LinearConstraint lc1 = parser.parse("a-b>=-1");
-    assertEquals(Number.parse("1"), lc1.getCoefficients().get("a"));
-    assertEquals(Number.parse("-1"), lc1.getCoefficients().get("b"));
-    assertEquals(LinearConstraint.Bound.LOWER, lc1.getBound());
+    assertEquals(Number.parse("1"), lc1.getDifference().getCoefficients().get("a"));
+    assertEquals(Number.parse("-1"), lc1.getDifference().getCoefficients().get("b"));
+    assertEquals(GREATER_EQUALS, lc1.getBound());
+
+    LinearConstraint lc2 = parser.parse("3x-2<=-2y+1");
+    assertEquals(Number.parse("3"), lc2.getDifference().getCoefficients().get("x"));
+    assertEquals(Number.parse("2"), lc2.getDifference().getCoefficients().get("y"));
+    assertEquals(Number.parse("-3"), lc2.getDifference().getConstant());
+    assertEquals(LESS_EQUALS, lc2.getBound());
   }
 }

--- a/src/test/java/MultivariatePolynomialTest.java
+++ b/src/test/java/MultivariatePolynomialTest.java
@@ -145,7 +145,7 @@ public class MultivariatePolynomialTest {
     assertEquals(number(0), result.getCoefficient(exponent(1, 0, 0)));
     assertEquals(number(0), result.getCoefficient(exponent(1, 1, 0)));
     assertEquals(number(0), result.getCoefficient(exponent(1, 2, 0)));
-    assertEquals(number(-1), result.getCoefficient(exponent(2, 2, 0))); // todo: investigate why the sign is wrong
+    assertEquals(number(-1), result.getCoefficient(exponent(2, 2, 0)));
 
   }
 
@@ -158,8 +158,6 @@ public class MultivariatePolynomialTest {
 
     Map<String, Interval> intervalMap = Map.of("x", xInterval, "y", yInterval);
     Interval result = p.evaluate(intervalMap);
-
-    System.out.println(result);
 
     assertFalse(result.containsZero());
     assertEquals(1, result.sign());


### PR DESCRIPTION
Add support for constraints in linear real arithmetic which aren't in normal form.

Example:
```
> smt QF_LRA (m=1+s) & (s=1+1/4m+1/2c) & (c=1+1/2s)
SAT:
c=11/4; m=9/2; s=7/2;
Time: 8ms
```