### PR TITLE
Fix bit-vector division/remainder by zero (SMT-LIB QF_BV semantics)

### DIFF
--- a/src/main/java/me/paultristanwagner/satchecking/theory/bitvector/BitVectorFlattener.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/bitvector/BitVectorFlattener.java
@@ -866,14 +866,26 @@ public class BitVectorFlattener {
       String signBitVariableTerm1 = bitVectorVariableToName.get(term1) + "_" + (term1.getLength() - 1);
       String signBitVariableRemainder = bitVectorVariableToName.get(remainder) + "_" + (remainder.getLength() - 1);
 
-      remainderRestriction = equivalence(
-          or(
-              and(zeroCase),
-              variable(signBitVariableRemainder)
-          ),
-          variable(signBitVariableTerm1)
+      // The remainder of a truncating division has the same sign as the dividend
+      // (or is zero). Note: this must be a disjunction; the previous biconditional
+      // formulation wrongly forced UNSAT whenever the division was exact (remainder 0)
+      // and the dividend was negative, or vice-versa.
+      remainderRestriction = or(
+          and(zeroCase),
+          equivalence(
+              variable(signBitVariableRemainder),
+              variable(signBitVariableTerm1)
+          )
       );
     }
+
+    // SMT-LIB QF_BV semantics for division by zero. Division by zero must not
+    // force UNSAT; instead the result takes a fixed value. The l = q*r + rem
+    // encoding (with rem < r) is only meaningful when the divisor is non-zero,
+    // so it is guarded by !divisorIsZero.
+    PropositionalLogicExpression divisorIsZero = divisorIsZeroExpression(term2);
+    PropositionalLogicExpression divisionByZeroResult =
+        divisionByZeroResultExpression(division, term1);
 
     return and(
         convertTermNonRecursive(extendedCoefficient),
@@ -882,9 +894,15 @@ public class BitVectorFlattener {
         convertTermNonRecursive(extendedRemainder),
         convertTermNonRecursive(product),
         convertTermNonRecursive(addition),
-        convertConstraintNonRecursive(equalConstraint),
-        lessThanExpression,
-        remainderRestriction
+        implication(
+            negation(divisorIsZero),
+            and(
+                convertConstraintNonRecursive(equalConstraint),
+                lessThanExpression,
+                remainderRestriction
+            )
+        ),
+        implication(divisorIsZero, divisionByZeroResult)
     );
   }
 
@@ -949,6 +967,14 @@ public class BitVectorFlattener {
       );
     }
 
+    // SMT-LIB QF_BV semantics for remainder by zero: bvurem(x, 0) = x and
+    // bvsrem(x, 0) = x. Remainder by zero must not force UNSAT; the
+    // l = q*r + rem encoding (with rem < r) is only meaningful for a non-zero
+    // divisor, so it is guarded by !divisorIsZero.
+    PropositionalLogicExpression divisorIsZero = divisorIsZeroExpression(term2);
+    PropositionalLogicExpression remainderByZeroResult =
+        equalBitsExpression(remainder, term1);
+
     return and(
         convertTermRecursive(extendedCoefficient),
         convertTermNonRecursive(extendedTerm1),
@@ -956,10 +982,89 @@ public class BitVectorFlattener {
         convertTermNonRecursive(extendedResult),
         convertTermNonRecursive(product),
         convertTermNonRecursive(addition),
-        convertConstraintNonRecursive(equalConstraint),
-        lessThanExpression,
-        remainderRestriction
+        implication(
+            negation(divisorIsZero),
+            and(
+                convertConstraintNonRecursive(equalConstraint),
+                lessThanExpression,
+                remainderRestriction
+            )
+        ),
+        implication(divisorIsZero, remainderByZeroResult)
     );
+  }
+
+  // Builds a propositional condition that is true iff the (non-extended) divisor
+  // term evaluates to zero, i.e. all of its bits are zero.
+  private PropositionalLogicExpression divisorIsZeroExpression(BitVectorTerm divisor) {
+    String divisorVariable = bitVectorVariableToName.get(divisor);
+
+    List<PropositionalLogicExpression> bitIsZero = new ArrayList<>();
+    for (int i = 0; i < divisor.getLength(); i++) {
+      bitIsZero.add(negation(variable(divisorVariable + "_" + i)));
+    }
+
+    return and(bitIsZero);
+  }
+
+  // Asserts that the result term equals the source term bit for bit (over the
+  // result length). Used for x % 0 = x.
+  private PropositionalLogicExpression equalBitsExpression(
+      BitVectorTerm resultTerm, BitVectorTerm sourceTerm) {
+    String resultVariable = bitVectorVariableToName.get(resultTerm);
+    String sourceVariable = bitVectorVariableToName.get(sourceTerm);
+
+    List<PropositionalLogicExpression> bitEqualities = new ArrayList<>();
+    for (int i = 0; i < resultTerm.getLength(); i++) {
+      bitEqualities.add(
+          equivalence(
+              variable(resultVariable + "_" + i),
+              variable(sourceVariable + "_" + i)));
+    }
+
+    return and(bitEqualities);
+  }
+
+  // Result value of dividend / 0 according to SMT-LIB QF_BV semantics.
+  // For unsigned division (bvudiv) and for non-negative signed dividends the
+  // result is all ones (2^n - 1). For negative signed dividends (bvsdiv) the
+  // result is one. The dividend's sign bit selects between the two cases; for
+  // an unsigned dividend (sign bit always treated as a value bit) the all-ones
+  // branch is selected whenever the top bit is zero, matching bvudiv on the
+  // values reachable here.
+  private PropositionalLogicExpression divisionByZeroResultExpression(
+      BitVectorTerm resultTerm, BitVectorTerm dividend) {
+    String resultVariable = bitVectorVariableToName.get(resultTerm);
+    String dividendVariable = bitVectorVariableToName.get(dividend);
+
+    int length = resultTerm.getLength();
+    String dividendSignBit = dividendVariable + "_" + (length - 1);
+
+    List<PropositionalLogicExpression> allOnesCase = new ArrayList<>();
+    List<PropositionalLogicExpression> oneCase = new ArrayList<>();
+    for (int i = 0; i < length; i++) {
+      String bit = resultVariable + "_" + i;
+
+      // all ones: every bit set
+      allOnesCase.add(variable(bit));
+
+      // value one: only bit 0 set
+      if (i == 0) {
+        oneCase.add(variable(bit));
+      } else {
+        oneCase.add(negation(variable(bit)));
+      }
+    }
+
+    if (!resultTerm.isSigned()) {
+      // bvudiv(x, 0) = 1...1
+      return and(allOnesCase);
+    }
+
+    // bvsdiv(x, 0) = ite(msb(x) = 0, 1...1, 1)
+    return and(
+        implication(negation(variable(dividendSignBit)), and(allOnesCase)),
+        implication(variable(dividendSignBit), and(oneCase)));
   }
 
   private static PropositionalLogicExpression halfAdderFormula(

--- a/src/test/java/BitVectorDivisionByZeroTest.java
+++ b/src/test/java/BitVectorDivisionByZeroTest.java
@@ -1,0 +1,95 @@
+import me.paultristanwagner.satchecking.sat.solver.DPLLCDCLSolver;
+import me.paultristanwagner.satchecking.smt.SMTResult;
+import me.paultristanwagner.satchecking.smt.TheoryCNF;
+import me.paultristanwagner.satchecking.smt.VariableAssignment;
+import me.paultristanwagner.satchecking.smt.solver.SMTSolver;
+import me.paultristanwagner.satchecking.theory.Theory;
+import me.paultristanwagner.satchecking.theory.bitvector.constraint.BitVectorConstraint;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for issue #14: bit-vector division/remainder by zero must
+ * not force a spurious UNSAT. The bit width defaults to 8 bits in this solver,
+ * and {@code /} and {@code %} are signed operators (bvsdiv / bvsrem). For the
+ * non-negative dividends used here the divide-by-zero result coincides with the
+ * unsigned {@code bvudiv} / {@code bvurem} values, i.e. all-ones / the dividend.
+ */
+public class BitVectorDivisionByZeroTest {
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static SMTResult solve(String formula) {
+    Theory theory = Theory.get("QF_BV");
+    var parser = theory.getCNFParser();
+    SMTSolver solver = theory.getSMTSolver();
+    solver.setSATSolver(new DPLLCDCLSolver());
+    solver.setTheorySolver(theory.getTheorySolver());
+
+    TheoryCNF<BitVectorConstraint> cnf =
+        (TheoryCNF<BitVectorConstraint>) parser.parseWithRemaining(formula).result();
+    solver.load(cnf);
+
+    return solver.solve();
+  }
+
+  // The BV theory solver stores each variable's value as a string of the form
+  // "0b<bits> (<decimal>)"; we recover the unsigned numeric value from the bits.
+  private static long unsignedValueOf(SMTResult result, String variable) {
+    VariableAssignment solution = result.getSolution();
+    String rendered = String.valueOf(solution.getAssignment(variable));
+
+    int start = rendered.indexOf("0b") + 2;
+    int end = rendered.indexOf(' ', start);
+    if (end < 0) {
+      end = rendered.length();
+    }
+    String bits = rendered.substring(start, end);
+
+    return Long.parseLong(bits, 2);
+  }
+
+  @Test
+  public void divisionByZeroIsSatAndAllOnes() {
+    SMTResult result = solve("(y = 0) & (x = 1) & (x / y = z)");
+
+    assertTrue(result.isSatisfiable(), "x / 0 must be SAT, not UNSAT");
+    // bvudiv(x, 0) = bvsdiv(x >= 0, 0) = all ones = 255 for 8-bit.
+    assertEquals(255L, unsignedValueOf(result, "z"));
+  }
+
+  @Test
+  public void remainderByZeroIsSatAndEqualsDividend() {
+    SMTResult result = solve("(y = 0) & (x = 5) & (x % y = z)");
+
+    assertTrue(result.isSatisfiable(), "x % 0 must be SAT, not UNSAT");
+    // bvurem(x, 0) = bvsrem(x, 0) = x = 5.
+    assertEquals(5L, unsignedValueOf(result, "z"));
+  }
+
+  @Test
+  public void normalDivisionStillWorks() {
+    SMTResult result = solve("(x = 6) & (y = 2) & (x / y = z)");
+
+    assertTrue(result.isSatisfiable());
+    assertEquals(3L, unsignedValueOf(result, "z"));
+  }
+
+  @Test
+  public void normalRemainderStillWorks() {
+    SMTResult result = solve("(x = 7) & (y = 2) & (x % y = z)");
+
+    assertTrue(result.isSatisfiable());
+    assertEquals(1L, unsignedValueOf(result, "z"));
+  }
+
+  @Test
+  public void divisionByZeroResultIsPinned() {
+    // The divide-by-zero result is fixed (255), so demanding a different value
+    // must be UNSAT. This guards against "anything goes" under-constraining.
+    SMTResult result = solve("(y = 0) & (x = 1) & (x / y = z) & (z = 5)");
+
+    assertTrue(!result.isSatisfiable(), "x / 0 result must be pinned to all-ones");
+  }
+}


### PR DESCRIPTION
## #14 — Bit-vector division/remainder by zero → spurious UNSAT

The `l = q·r + rem ∧ rem < r` encoding made `rem < 0` (unsatisfiable) when the divisor `r = 0`, so any formula with `x / 0` was forced **UNSAT**, contradicting SMT-LIB QF_BV.

Fix (guarded implications): `!divisorIsZero ⇒ (l=q·r+rem ∧ rem<r)`, `divisorIsZero ⇒ result = spec`, where `bvudiv(x,0)=1…1`, `bvsdiv(x,0)=ite(msb x, 1, 1…1)`, `bvurem/bvsrem(x,0)=x`.

While here, also corrected a pre-existing over-constrained signed-remainder **biconditional** that forced UNSAT on exact signed division (e.g. `6/2` was UNSAT) — see #15 (partially addressed).

Verified: `1/0=255`, `5%0=5`, normal `6/2=3`, `7%2=1`, and signed sanity (`-1/0=1`, `-6/2=-3`). Test `BitVectorDivisionByZeroTest` added. Closes #14.
