### PR TITLE
Fix optimization objective ignored by lazy SMT loop

### DIFF
--- a/src/main/java/me/paultristanwagner/satchecking/smt/solver/FullLazySMTSolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/smt/solver/FullLazySMTSolver.java
@@ -4,8 +4,11 @@ import me.paultristanwagner.satchecking.sat.Assignment;
 import me.paultristanwagner.satchecking.sat.Clause;
 import me.paultristanwagner.satchecking.sat.Literal;
 import me.paultristanwagner.satchecking.smt.SMTResult;
+import me.paultristanwagner.satchecking.smt.VariableAssignment;
 import me.paultristanwagner.satchecking.theory.Constraint;
+import me.paultristanwagner.satchecking.theory.SimplexResult;
 import me.paultristanwagner.satchecking.theory.TheoryResult;
+import me.paultristanwagner.satchecking.theory.arithmetic.Number;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -17,6 +20,16 @@ public class FullLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
   @Override
   public SMTResult<C> solve() {
     satSolver.load(cnf.getBooleanStructure());
+
+    // Tracking for the optimization case: we cannot return on the first theory-satisfiable
+    // Boolean model, because a different Boolean model may yield a better optimum. We therefore
+    // enumerate all theory-consistent Boolean models and keep the best optimum seen.
+    boolean objectivePresent = false;
+    boolean maximizing = false;
+    boolean foundOptimizationSolution = false;
+    boolean unbounded = false;
+    Number bestOptimum = null;
+    VariableAssignment bestSolution = null;
 
     Assignment assignment;
     while ((assignment = satSolver.nextModel()) != null) {
@@ -41,7 +54,47 @@ public class FullLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
         return SMTResult.unknown();
       }
 
+      // Determine whether this run carries an optimization objective. A SimplexResult that is
+      // optimal (or unbounded) signals that an objective function was attached to the model.
+      boolean optimizationResult =
+          theoryResult instanceof SimplexResult simplexResult
+              && (simplexResult.isOptimal() || simplexResult.isUnbounded());
+
+      if (optimizationResult) {
+        SimplexResult simplexResult = (SimplexResult) theoryResult;
+
+        if (!objectivePresent) {
+          objectivePresent = true;
+          maximizing = isMaximizing(selectedConstraints);
+        }
+
+        if (simplexResult.isUnbounded()) {
+          // The objective is unbounded for this model; no finite optimum can beat it.
+          unbounded = true;
+          foundOptimizationSolution = true;
+          bestSolution = simplexResult.getSolution();
+          // Keep enumerating is pointless once unbounded; the global optimum is unbounded.
+          break;
+        }
+
+        Number optimum = simplexResult.getOptimum();
+        if (bestOptimum == null
+            || (maximizing
+                ? optimum.greaterThan(bestOptimum)
+                : optimum.lessThan(bestOptimum))) {
+          bestOptimum = optimum;
+          bestSolution = simplexResult.getSolution();
+        }
+        foundOptimizationSolution = true;
+
+        // Do NOT return: continue enumerating alternative Boolean models. nextModel() blocks the
+        // current complete assignment, so the enumeration terminates.
+        continue;
+      }
+
       if (theoryResult.isSatisfiable()) {
+        // No optimization objective: keep the original behavior and return on the first
+        // theory-satisfiable Boolean model.
         return SMTResult.satisfiable(theoryResult.getSolution());
       }
 
@@ -58,6 +111,26 @@ public class FullLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
       cnf.getBooleanStructure().learnClause(clause);
     }
 
+    if (objectivePresent && foundOptimizationSolution) {
+      // Return the best optimum found across all enumerated theory-consistent models.
+      // The unbounded case is reported as satisfiable with the witnessing solution.
+      return SMTResult.satisfiable(bestSolution);
+    }
+
     return SMTResult.unsatisfiable();
+  }
+
+  private boolean isMaximizing(Set<C> selectedConstraints) {
+    for (C constraint : selectedConstraints) {
+      if (constraint instanceof me.paultristanwagner.satchecking.theory.LinearConstraint.MaximizingConstraint) {
+        return true;
+      }
+      if (constraint instanceof me.paultristanwagner.satchecking.theory.LinearConstraint.MinimizingConstraint) {
+        return false;
+      }
+    }
+    // Default: SimplexOptimizationSolver internally maximizes; without an explicit objective
+    // constraint in the selected set we conservatively treat it as maximization.
+    return true;
   }
 }

--- a/src/main/java/me/paultristanwagner/satchecking/smt/solver/LessLazySMTSolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/smt/solver/LessLazySMTSolver.java
@@ -5,8 +5,11 @@ import me.paultristanwagner.satchecking.sat.Literal;
 import me.paultristanwagner.satchecking.sat.PartialAssignment;
 import me.paultristanwagner.satchecking.sat.solver.DPLLCDCLSolver;
 import me.paultristanwagner.satchecking.smt.SMTResult;
+import me.paultristanwagner.satchecking.smt.VariableAssignment;
 import me.paultristanwagner.satchecking.theory.Constraint;
+import me.paultristanwagner.satchecking.theory.SimplexResult;
 import me.paultristanwagner.satchecking.theory.TheoryResult;
+import me.paultristanwagner.satchecking.theory.arithmetic.Number;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +20,16 @@ public class LessLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
   @Override
   public SMTResult<C> solve() {
     satSolver.load(cnf.getBooleanStructure());
+
+    // Optimization tracking (see issue #20). For objective-bearing instances we must compare
+    // optima across all theory-consistent complete Boolean models rather than returning the
+    // first one. The currently wired theory for this solver (QF_EQ) carries no objective, so this
+    // path is dormant there; it is kept consistent with FullLazySMTSolver for robustness.
+    boolean objectivePresent = false;
+    boolean maximizing = true;
+    boolean foundOptimizationSolution = false;
+    Number bestOptimum = null;
+    VariableAssignment bestSolution = null;
 
     int lastLevel = 0;
     PartialAssignment assignment;
@@ -47,7 +60,43 @@ public class LessLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
         return SMTResult.unknown();
       }
 
-      if (theoryResult.isSatisfiable()) {
+      boolean optimizationResult =
+          theoryResult instanceof SimplexResult simplexResult
+              && (simplexResult.isOptimal() || simplexResult.isUnbounded());
+
+      if (optimizationResult && assignment.isComplete()) {
+        // An objective is present: do not return on the first theory-SAT complete model; track the
+        // best optimum and force the SAT solver to enumerate a different complete model by
+        // excluding the current one.
+        SimplexResult simplexResult = (SimplexResult) theoryResult;
+        if (!objectivePresent) {
+          objectivePresent = true;
+          maximizing = simplexResult.isOptimal() ? isMaximizing(assignment) : true;
+        }
+
+        if (simplexResult.isUnbounded()) {
+          foundOptimizationSolution = true;
+          bestSolution = simplexResult.getSolution();
+          break;
+        }
+
+        Number optimum = simplexResult.getOptimum();
+        if (bestOptimum == null
+            || (maximizing ? optimum.greaterThan(bestOptimum) : optimum.lessThan(bestOptimum))) {
+          bestOptimum = optimum;
+          bestSolution = simplexResult.getSolution();
+        }
+        foundOptimizationSolution = true;
+
+        // Exclude the current complete model so enumeration advances.
+        Clause blocking = new Clause(blockingLiterals(assignment));
+        boolean resolvable = ((DPLLCDCLSolver) satSolver).excludeClause(blocking);
+        if (!resolvable) {
+          break;
+        }
+        theorySolver.clear();
+        lastLevel = 0;
+      } else if (theoryResult.isSatisfiable()) {
         if (assignment.isComplete()) {
           return SMTResult.satisfiable(theoryResult.getSolution());
         }
@@ -68,6 +117,36 @@ public class LessLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
       }
     }
 
+    if (objectivePresent && foundOptimizationSolution) {
+      return SMTResult.satisfiable(bestSolution);
+    }
+
     return SMTResult.unsatisfiable();
+  }
+
+  private List<Literal> blockingLiterals(PartialAssignment assignment) {
+    List<Literal> literals = new ArrayList<>();
+    for (Literal trueLiteral : assignment.getTrueLiterals()) {
+      literals.add(new Literal(trueLiteral.getName()).not());
+    }
+    return literals;
+  }
+
+  private boolean isMaximizing(PartialAssignment assignment) {
+    for (Literal trueLiteral : assignment.getTrueLiterals()) {
+      if (!cnf.getConstraintLiteralMap().inverse().containsKey(trueLiteral.getName())) {
+        continue;
+      }
+      C constraint = cnf.getConstraintLiteralMap().inverse().get(trueLiteral.getName());
+      if (constraint
+          instanceof me.paultristanwagner.satchecking.theory.LinearConstraint.MaximizingConstraint) {
+        return true;
+      }
+      if (constraint
+          instanceof me.paultristanwagner.satchecking.theory.LinearConstraint.MinimizingConstraint) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/test/java/SMTOptimizationLoopTest.java
+++ b/src/test/java/SMTOptimizationLoopTest.java
@@ -1,0 +1,86 @@
+import me.paultristanwagner.satchecking.parse.ParseResult;
+import me.paultristanwagner.satchecking.parse.TheoryCNFParser;
+import me.paultristanwagner.satchecking.sat.solver.DPLLCDCLSolver;
+import me.paultristanwagner.satchecking.smt.SMTResult;
+import me.paultristanwagner.satchecking.smt.TheoryCNF;
+import me.paultristanwagner.satchecking.smt.VariableAssignment;
+import me.paultristanwagner.satchecking.smt.solver.SMTSolver;
+import me.paultristanwagner.satchecking.theory.Theory;
+import me.paultristanwagner.satchecking.theory.arithmetic.Number;
+import me.paultristanwagner.satchecking.theory.solver.TheorySolver;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for issue #20: the lazy SMT loop must compare optima across all
+ * theory-consistent Boolean models and return the global optimum, not the optimum of whichever
+ * Boolean model the SAT solver happened to enumerate first.
+ */
+public class SMTOptimizationLoopTest {
+
+  @SuppressWarnings("unchecked")
+  private static SMTResult<?> solve(String formula) {
+    Theory theory = Theory.get("QF_LRA");
+    TheoryCNFParser parser = theory.getCNFParser();
+    SMTSolver solver = theory.getSMTSolver();
+    solver.setSATSolver(new DPLLCDCLSolver());
+    solver.setTheorySolver((TheorySolver) theory.getTheorySolver());
+
+    ParseResult<TheoryCNF<?>> pr = parser.parseWithRemaining(formula);
+    solver.load((TheoryCNF) pr.result());
+    return solver.solve();
+  }
+
+  private static Number valueOf(SMTResult<?> result, String variable) {
+    VariableAssignment<Number> solution = (VariableAssignment<Number>) result.getSolution();
+    return solution.getAssignment(variable);
+  }
+
+  private static void assertNumberEquals(long expected, Number actual) {
+    Number e = Number.number(expected);
+    assertTrue(
+        actual.greaterThanOrEqual(e) && actual.lessThanOrEqual(e),
+        "expected " + expected + " but was " + actual);
+  }
+
+  @Test
+  public void maximumIsOrderIndependent() {
+    // The optimum (max x = 100) must not depend on the order of the disjuncts.
+    SMTResult<?> a = solve("(x <= 100 | x <= 5) & (max(x))");
+    SMTResult<?> b = solve("(x <= 5 | x <= 100) & (max(x))");
+
+    assertTrue(a.isSatisfiable());
+    assertTrue(b.isSatisfiable());
+
+    assertNumberEquals(100, valueOf(a, "x"));
+    assertNumberEquals(100, valueOf(b, "x"));
+  }
+
+  @Test
+  public void minimumPicksGlobalOptimum() {
+    // x <= 0 rules out the (x >= 3) branch; the feasible branch is x in [-10, 0], so min x = -10.
+    SMTResult<?> result = solve("(x >= 3 | x >= -10) & (x <= 0) & (min(x))");
+
+    assertTrue(result.isSatisfiable());
+    assertNumberEquals(-10, valueOf(result, "x"));
+  }
+
+  @Test
+  public void minimumWithCoupledVariable() {
+    // y = 5 and x + y >= 12 force x >= 7; the (x <= -3) branch is then infeasible, so min x = 7.
+    SMTResult<?> result = solve("(x <= -3 | x >= 3) & (y = 5) & (x + y >= 12) & (min(x))");
+
+    assertTrue(result.isSatisfiable());
+    assertNumberEquals(7, valueOf(result, "x"));
+  }
+
+  @Test
+  public void nonObjectiveUnsatStillReported() {
+    // No objective present: the common case must not regress.
+    SMTResult<?> result = solve("(x <= 0 | x >= 5) & (x + y = 5/2) & (y = 1)");
+    assertFalse(result.isSatisfiable());
+    assertFalse(result.isUnknown());
+  }
+}


### PR DESCRIPTION
## #20 — min/max objective ignored by the lazy SMT loop

`FullLazySMTSolver`/`LessLazySMTSolver` returned on the **first** theory-satisfiable Boolean model, so with disjunctions + an objective the result was the optimum of whichever model was enumerated first — order-dependent and wrong:

```
(x <= 100 | x <= 5) & (max(x))   // returned x=5; true max is 100
```

Fix: when an objective is present (`SimplexResult.isOptimal()/isUnbounded()`), `FullLazySMTSolver` enumerates all theory-consistent models and returns the best optimum (max/min, unbounded short-circuit). Termination relies on the existing per-model blocking in `nextModel()`. No-objective solves keep the original first-model behavior (verified no regression). `LessLazySMTSolver` got the analogous handling defensively (it is wired only to QF_EQ, which carries no objective).

Verified order-independence (→100 either way), `min`→7, feasibility SAT/UNSAT unchanged. Test `SMTOptimizationLoopTest` added. Closes #20.
