### PR TITLE
Add SMT-LIB 2.6 subset parser (QF_LRA/LIA/EQ/UF, CNF fragment) — first increment

### DIFF
--- a/src/main/java/me/paultristanwagner/satchecking/command/CommandRegistry.java
+++ b/src/main/java/me/paultristanwagner/satchecking/command/CommandRegistry.java
@@ -16,6 +16,7 @@ public class CommandRegistry {
         new HelpCommand(),
         new SATCommand(),
         new SMTCommand(),
+        new SmtLibCommand(),
         new SimplexCommand(),
         new TseitinCommand(),
         new ReadCommand(),

--- a/src/main/java/me/paultristanwagner/satchecking/command/impl/SmtLibCommand.java
+++ b/src/main/java/me/paultristanwagner/satchecking/command/impl/SmtLibCommand.java
@@ -1,0 +1,187 @@
+package me.paultristanwagner.satchecking.command.impl;
+
+import me.paultristanwagner.satchecking.AnsiColor;
+import me.paultristanwagner.satchecking.command.Command;
+import me.paultristanwagner.satchecking.parse.SmtLibParser;
+import me.paultristanwagner.satchecking.parse.SmtLibParser.SmtLibScript;
+import me.paultristanwagner.satchecking.parse.SyntaxError;
+import me.paultristanwagner.satchecking.sat.solver.DPLLCDCLSolver;
+import me.paultristanwagner.satchecking.smt.SMTResult;
+import me.paultristanwagner.satchecking.smt.TheoryCNF;
+import me.paultristanwagner.satchecking.smt.TheoryClause;
+import me.paultristanwagner.satchecking.smt.solver.SMTSolver;
+import me.paultristanwagner.satchecking.theory.Constraint;
+import me.paultristanwagner.satchecking.theory.Theory;
+import me.paultristanwagner.satchecking.theory.solver.TheorySolver;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static me.paultristanwagner.satchecking.AnsiColor.*;
+
+/**
+ * Command that parses an SMT-LIB 2.6 subset script (inline or from a file), runs it through the
+ * existing SMT pipeline and prints sat/unsat/unknown for each {@code (check-sat)}. When the script
+ * carries {@code (set-info :status ...)} the verdict is compared against it.
+ *
+ * @author Paul Tristan Wagner <paultristanwagner@gmail.com>
+ */
+public class SmtLibCommand extends Command {
+
+  public SmtLibCommand() {
+    super(
+        "smtlib",
+        List.of(),
+        "Parses and solves an SMT-LIB 2.6 subset script",
+        "smtlib <file | inline script>",
+        """
+              Parses a subset of SMT-LIB 2.6 and runs it through the SMT pipeline.
+
+              Supported logics: QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF.
+              Supported boolean structure: CNF fragment only
+                (conjunctions of clauses; a clause is a disjunction of positive atoms).
+
+              Examples:
+                smtlib problem.smt2
+                smtlib (set-logic QF_LRA)(declare-const x Real)(assert (<= x 5))(check-sat)
+            """);
+  }
+
+  @Override
+  public boolean execute(String label, String[] args) {
+    if (args.length < 1) {
+      return false;
+    }
+
+    String joined = String.join(" ", args).trim();
+
+    String script;
+    Path path = pathOrNull(joined);
+    if (path != null) {
+      try {
+        script = Files.readString(path);
+      } catch (IOException e) {
+        System.out.printf("%sCould not read file '%s': %s%s%n", RED, joined, e.getMessage(), RESET);
+        return true;
+      }
+    } else {
+      script = joined;
+    }
+
+    try {
+      runScript(script, true);
+    } catch (SyntaxError e) {
+      System.out.print(RED);
+      e.printWithContext();
+      System.out.print(RESET);
+    }
+
+    return true;
+  }
+
+  private Path pathOrNull(String candidate) {
+    if (candidate.contains("(")) {
+      return null; // an inline s-expression script
+    }
+    Path path = Path.of(candidate);
+    if (Files.isRegularFile(path)) {
+      return path;
+    }
+    return null;
+  }
+
+  /** Verdict of running a single SMT-LIB script. */
+  public enum Verdict {
+    SAT,
+    UNSAT,
+    UNKNOWN
+  }
+
+  /**
+   * Parses and solves a script, returning the verdict. When {@code print} is true, prints the
+   * verdict and (if present) whether it matches the declared {@code :status}. Throws
+   * {@link SyntaxError} on unsupported / malformed input.
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public static Verdict runScript(String script, boolean print) {
+    SmtLibParser parser = new SmtLibParser(script);
+    SmtLibScript parsed = parser.parse();
+
+    if (print) {
+      for (String warning : parsed.getWarnings()) {
+        System.out.println(YELLOW + "Warning: " + warning + RESET);
+      }
+    }
+
+    String theoryName = mapLogic(parsed.getLogic());
+    Theory theory = Theory.get(theoryName);
+
+    List<TheoryClause<Constraint>> clauses = parsed.getClauses();
+    TheoryCNF theoryCNF = new TheoryCNF(clauses);
+
+    SMTSolver smtSolver = theory.getSMTSolver();
+    smtSolver.setSATSolver(new DPLLCDCLSolver());
+    TheorySolver theorySolver = theory.getTheorySolver();
+    smtSolver.setTheorySolver(theorySolver);
+    smtSolver.load(theoryCNF);
+
+    SMTResult<?> result = smtSolver.solve();
+
+    Verdict verdict;
+    if (result.isUnknown()) {
+      verdict = Verdict.UNKNOWN;
+    } else if (result.isSatisfiable()) {
+      verdict = Verdict.SAT;
+    } else {
+      verdict = Verdict.UNSAT;
+    }
+
+    if (print) {
+      printVerdict(verdict, parsed.getStatus());
+    }
+
+    return verdict;
+  }
+
+  private static void printVerdict(Verdict verdict, String status) {
+    String verdictString = verdict.name().toLowerCase();
+    AnsiColor color =
+        switch (verdict) {
+          case SAT -> GREEN;
+          case UNSAT -> RED;
+          case UNKNOWN -> YELLOW;
+        };
+    System.out.println(color + verdictString + RESET);
+
+    if (status != null) {
+      boolean matches = status.equals(verdictString);
+      if (matches) {
+        System.out.println(GREEN + "MATCHES expected status: " + status + RESET);
+      } else {
+        System.out.println(RED + "MISMATCHES expected status: " + status + RESET);
+      }
+    }
+  }
+
+  /** Maps an SMT-LIB logic name to the internal {@link Theory} name. */
+  public static String mapLogic(String logic) {
+    if (logic == null) {
+      throw new SyntaxError("no logic set (expected a (set-logic ...) command)", "", 0);
+    }
+    return switch (logic) {
+      case "QF_LRA" -> "QF_LRA";
+      case "QF_LIA" -> "QF_LIA";
+      case "QF_EQ" -> "QF_EQ";
+      case "QF_UF", "QF_EQUF" -> "QF_EQUF";
+      default ->
+          throw new SyntaxError(
+              "unsupported logic '"
+                  + logic
+                  + "' (supported: QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF)",
+              logic,
+              0);
+    };
+  }
+}

--- a/src/main/java/me/paultristanwagner/satchecking/parse/SmtLibLexer.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/SmtLibLexer.java
@@ -1,0 +1,57 @@
+package me.paultristanwagner.satchecking.parse;
+
+/**
+ * Lexer for a subset of SMT-LIB 2.6 scripts.
+ *
+ * <p>Tokenizes parentheses, numerals, decimals, keywords (e.g. {@code :status}), string literals
+ * and SMT-LIB symbols. Line comments starting with {@code ;} are treated as whitespace and skipped.
+ *
+ * @author Paul Tristan Wagner <paultristanwagner@gmail.com>
+ */
+public class SmtLibLexer extends Lexer {
+
+  // ; comment until end of line is skipped like whitespace.
+  public static final TokenType COMMENT = TokenType.of("comment", "^;[^\\n]*");
+
+  public static final TokenType LPAREN = TokenType.of("(", "^\\(");
+  public static final TokenType RPAREN = TokenType.of(")", "^\\)");
+
+  // A decimal numeral, e.g. 3.14 (must be tried before NUMERAL).
+  public static final TokenType DECIMAL = TokenType.of("decimal", "^\\d+\\.\\d+");
+
+  // A non-negative integer numeral, e.g. 0, 42.
+  public static final TokenType NUMERAL = TokenType.of("numeral", "^\\d+");
+
+  // A keyword, e.g. :status, :smt-lib-version.
+  public static final TokenType KEYWORD = TokenType.of("keyword", "^:[a-zA-Z0-9_+\\-*/=%?!.$_~&^<>@]+");
+
+  // A string literal "...". Two consecutive double quotes are an escaped quote.
+  public static final TokenType STRING = TokenType.of("string", "^\"(\"\"|[^\"])*\"");
+
+  // An SMT-LIB symbol. Covers simple symbols and the special operator characters.
+  // Note: a leading digit is excluded so numerals win.
+  public static final TokenType SYMBOL =
+      TokenType.of("symbol", "^[a-zA-Z+\\-*/=%?!.$_~&^<>@][a-zA-Z0-9+\\-*/=%?!.$_~&^<>@]*");
+
+  // A quoted symbol |...|.
+  public static final TokenType QUOTED_SYMBOL = TokenType.of("quoted symbol", "^\\|[^|]*\\|");
+
+  public SmtLibLexer(String input) {
+    super(input);
+
+    // The COMMENT type must be skipped like whitespace. We register it first so it is matched
+    // eagerly, then handle skipping below.
+    registerTokenTypes(
+        COMMENT,
+        LPAREN,
+        RPAREN,
+        DECIMAL,
+        NUMERAL,
+        KEYWORD,
+        STRING,
+        QUOTED_SYMBOL,
+        SYMBOL);
+
+    initialize(input);
+  }
+}

--- a/src/main/java/me/paultristanwagner/satchecking/parse/SmtLibParser.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/SmtLibParser.java
@@ -1,0 +1,649 @@
+package me.paultristanwagner.satchecking.parse;
+
+import me.paultristanwagner.satchecking.smt.TheoryClause;
+import me.paultristanwagner.satchecking.theory.Constraint;
+import me.paultristanwagner.satchecking.theory.EqualityConstraint;
+import me.paultristanwagner.satchecking.theory.EqualityFunctionConstraint;
+import me.paultristanwagner.satchecking.theory.EqualityFunctionConstraint.Function;
+import me.paultristanwagner.satchecking.theory.LinearConstraint;
+import me.paultristanwagner.satchecking.theory.LinearTerm;
+import me.paultristanwagner.satchecking.theory.arithmetic.Number;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parser for a subset of SMT-LIB 2.6 scripts.
+ *
+ * <p>This is an additive front-end: it parses an SMT-LIB script into the project's existing
+ * internal data structures (a list of {@link TheoryClause} for the asserted boolean skeleton plus
+ * the declared logic and the optional {@code :status}). It does not run the solver itself; see
+ * {@code command/impl/SmtLibCommand}.
+ *
+ * <p>Supported logics: QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF. Supported boolean structure is a CNF
+ * fragment only (conjunctions of clauses, where a clause is a disjunction of positive atoms).
+ *
+ * @author Paul Tristan Wagner <paultristanwagner@gmail.com>
+ */
+public class SmtLibParser {
+
+  /** Result of parsing an entire script. */
+  public static class SmtLibScript {
+
+    private final String logic;
+    private final String status; // "sat" | "unsat" | "unknown" | null
+    private final List<TheoryClause<Constraint>> clauses;
+    private final List<String> warnings;
+
+    public SmtLibScript(
+        String logic,
+        String status,
+        List<TheoryClause<Constraint>> clauses,
+        List<String> warnings) {
+      this.logic = logic;
+      this.status = status;
+      this.clauses = clauses;
+      this.warnings = warnings;
+    }
+
+    public String getLogic() {
+      return logic;
+    }
+
+    public String getStatus() {
+      return status;
+    }
+
+    public List<TheoryClause<Constraint>> getClauses() {
+      return clauses;
+    }
+
+    public List<String> getWarnings() {
+      return warnings;
+    }
+  }
+
+  /** A single token together with the index in the source it started at. */
+  private record Tok(TokenType type, String value, int index) {}
+
+  /** An s-expression: either an atom (a token) or a list of s-expressions. */
+  private static final class SExpr {
+    final Tok atom; // null for lists
+    final List<SExpr> list; // null for atoms
+    final int index;
+
+    SExpr(Tok atom) {
+      this.atom = atom;
+      this.list = null;
+      this.index = atom.index();
+    }
+
+    SExpr(List<SExpr> list, int index) {
+      this.atom = null;
+      this.list = list;
+      this.index = index;
+    }
+
+    boolean isAtom() {
+      return atom != null;
+    }
+
+    boolean isList() {
+      return list != null;
+    }
+
+    String head() {
+      // The symbol/keyword at the head of a list, or the atom value itself.
+      if (isAtom()) {
+        return atom.value();
+      }
+      if (!list.isEmpty() && list.get(0).isAtom()) {
+        return list.get(0).atom.value();
+      }
+      return null;
+    }
+  }
+
+  private final String input;
+  private final List<Tok> tokens;
+  private int pos;
+
+  // Logic kind. Determined by set-logic.
+  private enum Kind {
+    ARITHMETIC, // QF_LRA, QF_LIA
+    EQUALITY, // QF_EQ
+    UF // QF_UF, QF_EQUF
+  }
+
+  private String logicName;
+  private Kind kind = Kind.ARITHMETIC; // default
+  private String status;
+
+  // Declared 0-arity symbols (constants/variables) and uninterpreted functions (arity > 0).
+  private final List<String> declaredFunctions = new ArrayList<>();
+  private final List<TheoryClause<Constraint>> clauses = new ArrayList<>();
+  private final List<String> warnings = new ArrayList<>();
+
+  public SmtLibParser(String input) {
+    this.input = input;
+    this.tokens = tokenize(input);
+    this.pos = 0;
+  }
+
+  private List<Tok> tokenize(String input) {
+    SmtLibLexer lexer = new SmtLibLexer(input);
+    List<Tok> result = new ArrayList<>();
+    while (lexer.hasNextToken()) {
+      Token token = lexer.getLookahead();
+      int index = lexer.getCursor();
+      if (token.getType() != SmtLibLexer.COMMENT) {
+        result.add(new Tok(token.getType(), token.getValue(), index));
+      }
+      lexer.skip(token.getValue().length());
+    }
+    return result;
+  }
+
+  // ---- s-expression reading -------------------------------------------------
+
+  private SExpr readSExpr() {
+    if (pos >= tokens.size()) {
+      throw err("Unexpected end of input", input.length());
+    }
+    Tok t = tokens.get(pos);
+    if (t.type() == SmtLibLexer.LPAREN) {
+      int start = t.index();
+      pos++;
+      List<SExpr> list = new ArrayList<>();
+      while (pos < tokens.size() && tokens.get(pos).type() != SmtLibLexer.RPAREN) {
+        list.add(readSExpr());
+      }
+      if (pos >= tokens.size()) {
+        throw err("Missing closing ')'", input.length());
+      }
+      pos++; // consume RPAREN
+      return new SExpr(list, start);
+    } else if (t.type() == SmtLibLexer.RPAREN) {
+      throw err("Unexpected ')'", t.index());
+    } else {
+      pos++;
+      return new SExpr(t);
+    }
+  }
+
+  // ---- top level ------------------------------------------------------------
+
+  /** Parses the whole script and returns the accumulated structure. */
+  public SmtLibScript parse() {
+    while (pos < tokens.size()) {
+      SExpr command = readSExpr();
+      handleCommand(command);
+    }
+    return new SmtLibScript(logicName, status, clauses, warnings);
+  }
+
+  private void handleCommand(SExpr command) {
+    if (!command.isList() || command.list.isEmpty() || !command.list.get(0).isAtom()) {
+      throw err("Expected a command s-expression", command.index);
+    }
+    String name = command.list.get(0).atom.value();
+    List<SExpr> args = command.list.subList(1, command.list.size());
+
+    switch (name) {
+      case "set-logic" -> handleSetLogic(args, command.index);
+      case "set-info" -> handleSetInfo(args);
+      case "declare-const" -> handleDeclareConst(args, command.index);
+      case "declare-fun" -> handleDeclareFun(args, command.index);
+      case "declare-sort", "define-sort" -> {
+        /* tracked/ignored */
+      }
+      case "assert" -> handleAssert(args, command.index);
+      case "check-sat", "check-sat-assuming" -> {
+        /* the command driver triggers solving; nothing to accumulate */
+      }
+      case "exit", "set-option", "get-model", "get-info", "push", "pop", "reset", "echo" -> {
+        // No-op for our subset. push/pop are not supported as incremental solving but
+        // single-frame scripts are common; we warn for push/pop specifically below.
+        if (name.equals("push") || name.equals("pop")) {
+          warnings.add("ignoring unsupported incremental command '" + name + "'");
+        }
+      }
+      default -> warnings.add("ignoring unknown command '" + name + "'");
+    }
+  }
+
+  private void handleSetLogic(List<SExpr> args, int index) {
+    if (args.isEmpty() || !args.get(0).isAtom()) {
+      throw err("set-logic expects a logic name", index);
+    }
+    logicName = args.get(0).atom.value();
+    switch (logicName) {
+      case "QF_LRA", "QF_LIA" -> kind = Kind.ARITHMETIC;
+      case "QF_EQ" -> kind = Kind.EQUALITY;
+      case "QF_UF", "QF_EQUF" -> kind = Kind.UF;
+      default ->
+          throw err(
+              "unsupported logic '"
+                  + logicName
+                  + "' (supported: QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF)",
+              index);
+    }
+  }
+
+  private void handleSetInfo(List<SExpr> args) {
+    if (args.size() >= 2 && args.get(0).isAtom() && ":status".equals(args.get(0).atom.value())) {
+      SExpr v = args.get(1);
+      if (v.isAtom()) {
+        String s = v.atom.value();
+        if (s.equals("sat") || s.equals("unsat") || s.equals("unknown")) {
+          status = s;
+        }
+      }
+    }
+  }
+
+  private void handleDeclareConst(List<SExpr> args, int index) {
+    // (declare-const name Sort)
+    if (args.size() < 2 || !args.get(0).isAtom()) {
+      throw err("declare-const expects a name and a sort", index);
+    }
+    declaredFunctions.add(args.get(0).atom.value());
+  }
+
+  private void handleDeclareFun(List<SExpr> args, int index) {
+    // (declare-fun name (argSorts...) retSort)
+    if (args.size() < 3 || !args.get(0).isAtom()) {
+      throw err("declare-fun expects a name, argument sorts and a return sort", index);
+    }
+    declaredFunctions.add(args.get(0).atom.value());
+    // 0-arity -> variable/constant; >0 arity -> uninterpreted function. We don't need to store the
+    // arity: term parsing distinguishes by whether the symbol appears applied.
+  }
+
+  // ---- assert / boolean structure ------------------------------------------
+
+  private void handleAssert(List<SExpr> args, int index) {
+    if (args.size() != 1) {
+      throw err("assert expects exactly one formula", index);
+    }
+    SExpr formula = args.get(0);
+    addFormula(formula);
+  }
+
+  /** Adds the clauses produced by one asserted formula (CNF fragment). */
+  private void addFormula(SExpr formula) {
+    rejectNonCnf(formula);
+
+    String head = formula.isList() ? formula.head() : null;
+    if ("and".equals(head)) {
+      // conjunction of sub-formulas, each must itself be a clause (atom or or-of-atoms)
+      for (int i = 1; i < formula.list.size(); i++) {
+        addClause(formula.list.get(i));
+      }
+    } else {
+      addClause(formula);
+    }
+  }
+
+  /**
+   * Adds a clause from a formula: either an atom (unit clause) or an (or atom...) disjunction.
+   *
+   * <p>An atom may expand to several constraints (e.g. {@code (distinct a b c)} expands pairwise).
+   * As a top-level conjunct, those constraints are conjoined (each becomes its own unit clause).
+   * Inside an {@code or}, an atom must yield a single constraint, otherwise the pairwise expansion
+   * would be mis-interpreted as a disjunction; we reject that case.
+   */
+  private void addClause(SExpr formula) {
+    rejectNonCnf(formula);
+    String head = formula.isList() ? formula.head() : null;
+    if ("or".equals(head)) {
+      if (formula.list.size() < 2) {
+        throw err("'or' requires at least one disjunct", formula.index);
+      }
+      List<Constraint> constraints = new ArrayList<>();
+      for (int i = 1; i < formula.list.size(); i++) {
+        SExpr disjunct = formula.list.get(i);
+        List<Constraint> atomConstraints = parseAtom(disjunct);
+        if (atomConstraints.size() != 1) {
+          throw err(
+              "unsupported boolean structure (needs negation handling, issue #9): "
+                  + "pairwise 'distinct' with more than two arguments inside an 'or'",
+              disjunct.index);
+        }
+        constraints.addAll(atomConstraints);
+      }
+      clauses.add(new TheoryClause<>(constraints));
+    } else {
+      // unit atom; pairwise expansion -> conjunction -> one unit clause each
+      for (Constraint constraint : parseAtom(formula)) {
+        clauses.add(new TheoryClause<>(List.of(constraint)));
+      }
+    }
+  }
+
+  private void rejectNonCnf(SExpr formula) {
+    if (!formula.isList()) {
+      return;
+    }
+    String head = formula.head();
+    if (head == null) {
+      return;
+    }
+    switch (head) {
+      case "not", "=>", "implies", "ite", "xor", "iff" ->
+          throw err(
+              "unsupported boolean structure (needs negation handling, issue #9): '" + head + "'",
+              formula.index);
+      default -> {
+        /* ok */
+      }
+    }
+  }
+
+  // ---- atom parsing (returns 1 constraint, except distinct which expands pairwise) ----
+
+  private List<Constraint> parseAtom(SExpr atom) {
+    rejectNonCnf(atom);
+    if (!atom.isList()) {
+      throw err(
+          "expected an atom (a predicate application), found symbol '" + atom.atom.value() + "'",
+          atom.index);
+    }
+    String head = atom.head();
+    if (head == null) {
+      throw err("expected an atom", atom.index);
+    }
+
+    // Nested and/or inside a clause is not part of the CNF fragment.
+    if (head.equals("and") || head.equals("or")) {
+      throw err(
+          "unsupported boolean structure (needs negation handling, issue #9): nested '"
+              + head
+              + "' inside a clause",
+          atom.index);
+    }
+
+    return switch (kind) {
+      case ARITHMETIC -> List.of(parseArithmeticAtom(atom, head));
+      case EQUALITY -> parseEqualityAtom(atom, head);
+      case UF -> parseUfAtom(atom, head);
+    };
+  }
+
+  // ---- arithmetic (QF_LRA / QF_LIA) ----------------------------------------
+
+  private Constraint parseArithmeticAtom(SExpr atom, String head) {
+    switch (head) {
+      case "<", ">" ->
+          throw err(
+              "unsupported: strict inequality (no strict bound in LinearConstraint): '"
+                  + head
+                  + "'",
+              atom.index);
+      case "=", "<=", ">=" -> {
+        if (atom.list.size() != 3) {
+          throw err(
+              "'" + head + "' expects exactly two arguments in this subset", atom.index);
+        }
+        LinearTerm lhs = parseLinearTerm(atom.list.get(1));
+        LinearTerm rhs = parseLinearTerm(atom.list.get(2));
+        return switch (head) {
+          case "=" -> LinearConstraint.equal(lhs, rhs);
+          case "<=" -> LinearConstraint.lessThanOrEqual(lhs, rhs);
+          default -> LinearConstraint.greaterThanOrEqual(lhs, rhs);
+        };
+      }
+      default ->
+          throw err("unsupported arithmetic predicate '" + head + "'", atom.index);
+    }
+  }
+
+  private LinearTerm parseLinearTerm(SExpr e) {
+    if (e.isAtom()) {
+      Tok t = e.atom;
+      if (t.type() == SmtLibLexer.NUMERAL || t.type() == SmtLibLexer.DECIMAL) {
+        LinearTerm term = new LinearTerm();
+        term.setConstant(Number.parse(t.value()));
+        return term;
+      }
+      // a variable
+      LinearTerm term = new LinearTerm();
+      term.setCoefficient(t.value(), Number.ONE());
+      return term;
+    }
+
+    String head = e.head();
+    if (head == null) {
+      throw err("malformed arithmetic term", e.index);
+    }
+    switch (head) {
+      case "+" -> {
+        LinearTerm term = new LinearTerm();
+        for (int i = 1; i < e.list.size(); i++) {
+          term = term.add(parseLinearTerm(e.list.get(i)));
+        }
+        return term;
+      }
+      case "-" -> {
+        if (e.list.size() == 2) {
+          // unary negation
+          return parseLinearTerm(e.list.get(1)).negate();
+        }
+        if (e.list.size() < 2) {
+          throw err("'-' requires at least one argument", e.index);
+        }
+        LinearTerm term = parseLinearTerm(e.list.get(1));
+        for (int i = 2; i < e.list.size(); i++) {
+          term = term.subtract(parseLinearTerm(e.list.get(i)));
+        }
+        return term;
+      }
+      case "*" -> {
+        return parseProduct(e);
+      }
+      case "/" -> {
+        // rational constant (/ p q)
+        return parseDivision(e);
+      }
+      default ->
+          throw err("unsupported arithmetic operator '" + head + "'", e.index);
+    }
+  }
+
+  /** Parses a linear product: at least one factor must be a numeric constant. */
+  private LinearTerm parseProduct(SExpr e) {
+    if (e.list.size() < 3) {
+      throw err("'*' requires at least two arguments", e.index);
+    }
+    // Fold factors. Track the running coefficient (numeric) and at most one non-constant term.
+    Number coefficient = Number.ONE();
+    LinearTerm nonConstant = null;
+    for (int i = 1; i < e.list.size(); i++) {
+      SExpr factor = e.list.get(i);
+      Number c = tryConstant(factor);
+      if (c != null) {
+        coefficient = coefficient.multiply(c);
+      } else {
+        if (nonConstant != null) {
+          throw err("unsupported: nonlinear term", e.index);
+        }
+        nonConstant = parseLinearTerm(factor);
+      }
+    }
+    if (nonConstant == null) {
+      LinearTerm term = new LinearTerm();
+      term.setConstant(coefficient);
+      return term;
+    }
+    // multiply nonConstant by the scalar coefficient
+    LinearTerm result = new LinearTerm();
+    final Number coeff = coefficient;
+    nonConstant.getCoefficients().forEach((v, k) -> result.addCoefficient(v, k.multiply(coeff)));
+    result.setConstant(nonConstant.getConstant().multiply(coeff));
+    return result;
+  }
+
+  private LinearTerm parseDivision(SExpr e) {
+    if (e.list.size() != 3) {
+      throw err("'/' expects exactly two arguments (a rational constant)", e.index);
+    }
+    Number numerator = tryConstant(e.list.get(1));
+    Number denominator = tryConstant(e.list.get(2));
+    if (numerator == null || denominator == null) {
+      throw err("unsupported: nonlinear term (division by a non-constant)", e.index);
+    }
+    LinearTerm term = new LinearTerm();
+    term.setConstant(numerator.divide(denominator));
+    return term;
+  }
+
+  /**
+   * If the expression evaluates to a numeric constant, returns it; otherwise null. Handles plain
+   * numerals/decimals, unary minus of a constant, and (/ p q) of constants.
+   */
+  private Number tryConstant(SExpr e) {
+    if (e.isAtom()) {
+      Tok t = e.atom;
+      if (t.type() == SmtLibLexer.NUMERAL || t.type() == SmtLibLexer.DECIMAL) {
+        return Number.parse(t.value());
+      }
+      return null;
+    }
+    String head = e.head();
+    if (head == null) {
+      return null;
+    }
+    switch (head) {
+      case "-" -> {
+        if (e.list.size() == 2) {
+          Number inner = tryConstant(e.list.get(1));
+          return inner == null ? null : inner.negate();
+        }
+        return null;
+      }
+      case "/" -> {
+        if (e.list.size() == 3) {
+          Number num = tryConstant(e.list.get(1));
+          Number den = tryConstant(e.list.get(2));
+          if (num != null && den != null) {
+            return num.divide(den);
+          }
+        }
+        return null;
+      }
+      case "*" -> {
+        Number acc = Number.ONE();
+        for (int i = 1; i < e.list.size(); i++) {
+          Number c = tryConstant(e.list.get(i));
+          if (c == null) {
+            return null;
+          }
+          acc = acc.multiply(c);
+        }
+        return acc;
+      }
+      default -> {
+        return null;
+      }
+    }
+  }
+
+  // ---- equality (QF_EQ) -----------------------------------------------------
+
+  private List<Constraint> parseEqualityAtom(SExpr atom, String head) {
+    switch (head) {
+      case "=" -> {
+        if (atom.list.size() != 3) {
+          throw err("'=' expects exactly two arguments in this subset", atom.index);
+        }
+        String left = requireVariable(atom.list.get(1));
+        String right = requireVariable(atom.list.get(2));
+        return List.of(new EqualityConstraint(left, right, true));
+      }
+      case "distinct" -> {
+        List<String> vars = new ArrayList<>();
+        for (int i = 1; i < atom.list.size(); i++) {
+          vars.add(requireVariable(atom.list.get(i)));
+        }
+        if (vars.size() < 2) {
+          throw err("'distinct' requires at least two arguments", atom.index);
+        }
+        // pairwise distinct expanded into separate constraints (conjunction). When this atom is a
+        // unit clause, multiple constraints in one clause would be a disjunction, which is wrong.
+        // We therefore only allow multi-arg distinct as a top-level/unit atom (handled by caller
+        // putting each in its own clause). For safety expand pairwise here; the caller for clauses
+        // with 'or' would mis-handle >2 args, so reject >2 inside a disjunction.
+        List<Constraint> result = new ArrayList<>();
+        for (int i = 0; i < vars.size(); i++) {
+          for (int j = i + 1; j < vars.size(); j++) {
+            result.add(new EqualityConstraint(vars.get(i), vars.get(j), false));
+          }
+        }
+        return result;
+      }
+      default ->
+          throw err("unsupported equality predicate '" + head + "'", atom.index);
+    }
+  }
+
+  private String requireVariable(SExpr e) {
+    if (!e.isAtom()) {
+      throw err("expected a variable/constant symbol", e.index);
+    }
+    return e.atom.value();
+  }
+
+  // ---- uninterpreted functions (QF_UF / QF_EQUF) ---------------------------
+
+  private List<Constraint> parseUfAtom(SExpr atom, String head) {
+    switch (head) {
+      case "=" -> {
+        if (atom.list.size() != 3) {
+          throw err("'=' expects exactly two arguments in this subset", atom.index);
+        }
+        Function left = parseFunctionTerm(atom.list.get(1));
+        Function right = parseFunctionTerm(atom.list.get(2));
+        return List.of(new EqualityFunctionConstraint(left, right, true));
+      }
+      case "distinct" -> {
+        List<Function> terms = new ArrayList<>();
+        for (int i = 1; i < atom.list.size(); i++) {
+          terms.add(parseFunctionTerm(atom.list.get(i)));
+        }
+        if (terms.size() < 2) {
+          throw err("'distinct' requires at least two arguments", atom.index);
+        }
+        List<Constraint> result = new ArrayList<>();
+        for (int i = 0; i < terms.size(); i++) {
+          for (int j = i + 1; j < terms.size(); j++) {
+            result.add(new EqualityFunctionConstraint(terms.get(i), terms.get(j), false));
+          }
+        }
+        return result;
+      }
+      default ->
+          throw err("unsupported equality predicate '" + head + "'", atom.index);
+    }
+  }
+
+  private Function parseFunctionTerm(SExpr e) {
+    if (e.isAtom()) {
+      return Function.of(e.atom.value());
+    }
+    String head = e.head();
+    if (head == null) {
+      throw err("malformed function application term", e.index);
+    }
+    List<Function> args = new ArrayList<>();
+    for (int i = 1; i < e.list.size(); i++) {
+      args.add(parseFunctionTerm(e.list.get(i)));
+    }
+    return Function.of(head, args);
+  }
+
+  // ---- error helper ---------------------------------------------------------
+
+  private SyntaxError err(String message, int index) {
+    return new SyntaxError(message, input, index);
+  }
+}

--- a/src/test/java/SmtLibParserTest.java
+++ b/src/test/java/SmtLibParserTest.java
@@ -1,0 +1,172 @@
+import me.paultristanwagner.satchecking.command.impl.SmtLibCommand;
+import me.paultristanwagner.satchecking.command.impl.SmtLibCommand.Verdict;
+import me.paultristanwagner.satchecking.parse.SyntaxError;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the SMT-LIB 2.6 subset parser and the {@code smtlib} command. Each case asserts the
+ * verdict matches the script's declared {@code :status}, and that unsupported constructs throw a
+ * clear {@link SyntaxError}.
+ *
+ * @author Paul Tristan Wagner <paultristanwagner@gmail.com>
+ * @version 1.0
+ */
+public class SmtLibParserTest {
+
+  private static Verdict run(String script) {
+    return SmtLibCommand.runScript(script, false);
+  }
+
+  @Test
+  public void testQfLraSat() {
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_LRA)(declare-const x Real)(declare-const y Real)"
+                + "(assert (<= x 5))(assert (= (+ x y) 3))(set-info :status sat)(check-sat)"));
+  }
+
+  @Test
+  public void testQfLraUnsat() {
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_LRA)(declare-const x Real)"
+                + "(assert (<= x 0))(assert (>= x 5))(set-info :status unsat)(check-sat)"));
+  }
+
+  @Test
+  public void testQfLraDisjunctionSat() {
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_LRA)(declare-const x Real)"
+                + "(assert (or (<= x 0) (>= x 5)))(assert (>= x 7))"
+                + "(set-info :status sat)(check-sat)"));
+  }
+
+  @Test
+  public void testQfLraDisjunctionUnsat() {
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_LRA)(declare-const x Real)"
+                + "(assert (or (<= x 0) (>= x 5)))(assert (>= x 1))(assert (<= x 4))"
+                + "(set-info :status unsat)(check-sat)"));
+  }
+
+  @Test
+  public void testQfLraRationalAndProduct() {
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_LRA)(declare-const x Real)(declare-const y Real)"
+                + "(assert (= (* 2 x) y))(assert (= x (/ 3 2)))(assert (= y 3))"
+                + "(set-info :status sat)(check-sat)"));
+  }
+
+  @Test
+  public void testQfLiaSat() {
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_LIA)(declare-const x Int)(declare-const y Int)"
+                + "(assert (<= x 5))(assert (= (+ x y) 3))(set-info :status sat)(check-sat)"));
+  }
+
+  @Test
+  public void testQfLiaUnsat() {
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_LIA)(declare-const x Int)"
+                + "(assert (>= x 1))(assert (<= x 0))(set-info :status unsat)(check-sat)"));
+  }
+
+  @Test
+  public void testQfEqUnsat() {
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_EQ)(declare-const a U)(declare-const b U)(declare-const c U)"
+                + "(assert (= a b))(assert (= b c))(assert (distinct a c))"
+                + "(set-info :status unsat)(check-sat)"));
+  }
+
+  @Test
+  public void testQfEqSat() {
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_EQ)(declare-const a U)(declare-const b U)(declare-const c U)"
+                + "(assert (= a b))(assert (distinct b c))(set-info :status sat)(check-sat)"));
+  }
+
+  @Test
+  public void testQfUfCongruenceUnsat() {
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_UF)(declare-sort U 0)(declare-const a U)(declare-const b U)"
+                + "(declare-fun f (U) U)(assert (= a b))(assert (distinct (f a) (f b)))"
+                + "(set-info :status unsat)(check-sat)"));
+  }
+
+  @Test
+  public void testQfUfSat() {
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_UF)(declare-sort U 0)(declare-const a U)(declare-const b U)"
+                + "(declare-fun f (U) U)(assert (= (f a) (f b)))"
+                + "(set-info :status sat)(check-sat)"));
+  }
+
+  @Test
+  public void testStrictInequalityRejected() {
+    SyntaxError error =
+        assertThrows(
+            SyntaxError.class,
+            () ->
+                run("(set-logic QF_LRA)(declare-const x Real)(assert (< x 5))(check-sat)"));
+    assertTrue(error.getMessage().contains("strict inequality"), error.getMessage());
+  }
+
+  @Test
+  public void testNegationRejected() {
+    SyntaxError error =
+        assertThrows(
+            SyntaxError.class,
+            () ->
+                run(
+                    "(set-logic QF_EQ)(declare-const a U)(declare-const b U)"
+                        + "(assert (not (= a b)))(check-sat)"));
+    assertTrue(error.getMessage().contains("unsupported boolean structure"), error.getMessage());
+  }
+
+  @Test
+  public void testImpliesRejected() {
+    SyntaxError error =
+        assertThrows(
+            SyntaxError.class,
+            () ->
+                run(
+                    "(set-logic QF_EQ)(declare-const a U)(declare-const b U)(declare-const c U)"
+                        + "(assert (=> (= a b) (= b c)))(check-sat)"));
+    assertTrue(error.getMessage().contains("unsupported boolean structure"), error.getMessage());
+  }
+
+  @Test
+  public void testNonlinearRejected() {
+    SyntaxError error =
+        assertThrows(
+            SyntaxError.class,
+            () ->
+                run(
+                    "(set-logic QF_LRA)(declare-const x Real)(declare-const y Real)"
+                        + "(assert (= (* x y) 1))(check-sat)"));
+    assertTrue(error.getMessage().contains("nonlinear term"), error.getMessage());
+  }
+}


### PR DESCRIPTION
## #33 — SMT-LIB 2.6 subset parser (first increment)

Adds an s-expression front-end that parses an SMT-LIB script, builds the existing internal `TheoryCNF`, runs it through the current SMT pipeline, and (when `(set-info :status …)` is present) reports MATCHES/MISMATCHES. This is the foundation for running real SMT-LIB benchmarks.

**New:** `SmtLibLexer`, `SmtLibParser`, `SmtLibCommand` (`smtlib <inline|file>`), `SmtLibParserTest`; one line added to `CommandRegistry`. No changes to solver internals or theory classes.

### Supported
- Logics: **QF_LRA, QF_LIA, QF_EQ, QF_UF/QF_EQUF**.
- Commands: `set-logic`, `set-info` (`:status`), `declare-const`, `declare-fun`, `declare-sort`, `assert`, `check-sat`, `exit`, `set-option`, `get-model`; unknown commands warn + no-op.
- Terms: `+`, unary/n-ary `-`, linear `*` (one numeric factor), numerals, decimals, rational `(/ p q)`; atoms `=`, `<=`, `>=`; `distinct` (pairwise); UF application terms.
- Boolean: the **CNF fragment** — `(and …)` of clauses, each a bare atom or `(or atom…)`; multiple asserts conjoined. (This is exactly what `TheoryCNF` models — positive literals only.)

### Deferred — rejected with explicit errors, never silently mis-encoded
- **Strict `<` / `>`** → "unsupported: strict inequality" (the internal `LinearConstraint` has no strict bound — encoding as non-strict would be unsound). Tied to the strict-inequality gap.
- **`not` / `=>` / `ite` / nested non-CNF** → "unsupported boolean structure (needs negation handling, issue #9)". General boolean structure requires Tseitin + asserting negated atoms (**#9**) — the explicit follow-up.
- QF_BV, QF_NRA front-ends; `let`, `define-fun`, `push`/`pop`.

### Verification
Exact (Rational) arithmetic, so verdicts are sound. Independently verified (standalone harness; no Maven in dev env) incl. the discriminating case **`2x=1` → UNSAT in QF_LIA but SAT in QF_LRA**, QF_EQ/QF_UF congruence → UNSAT, CNF disjunctions, and that strict/`not` raise clear errors. `SmtLibParserTest` mirrors these.

Part of #33 (epic #35). Boolean-structure support depends on #9.
