### PR TITLE
SMT-LIB boolean structure for equality logics + sound negated-atom handling (#9, #33)

### DIFF
--- a/src/main/java/me/paultristanwagner/satchecking/command/impl/SmtLibCommand.java
+++ b/src/main/java/me/paultristanwagner/satchecking/command/impl/SmtLibCommand.java
@@ -40,8 +40,10 @@ public class SmtLibCommand extends Command {
               Parses a subset of SMT-LIB 2.6 and runs it through the SMT pipeline.
 
               Supported logics: QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF.
-              Supported boolean structure: CNF fragment only
-                (conjunctions of clauses; a clause is a disjunction of positive atoms).
+              Boolean structure:
+                - equality logics (QF_EQ, QF_UF, QF_EQUF): arbitrary structure
+                  (and/or/not/=>/xor/ite over equality atoms, incl. negation/distinct).
+                - arithmetic logics (QF_LRA, QF_LIA): CNF fragment of positive atoms only.
 
               Examples:
                 smtlib problem.smt2
@@ -118,8 +120,11 @@ public class SmtLibCommand extends Command {
     String theoryName = mapLogic(parsed.getLogic());
     Theory theory = Theory.get(theoryName);
 
-    List<TheoryClause<Constraint>> clauses = parsed.getClauses();
-    TheoryCNF theoryCNF = new TheoryCNF(clauses);
+    TheoryCNF theoryCNF = parsed.getTheoryCNF();
+    if (theoryCNF == null) {
+      List<TheoryClause<Constraint>> clauses = parsed.getClauses();
+      theoryCNF = new TheoryCNF(clauses);
+    }
 
     SMTSolver smtSolver = theory.getSMTSolver();
     smtSolver.setSATSolver(new DPLLCDCLSolver());

--- a/src/main/java/me/paultristanwagner/satchecking/parse/SmtLibParser.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/SmtLibParser.java
@@ -1,5 +1,16 @@
 package me.paultristanwagner.satchecking.parse;
 
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import me.paultristanwagner.satchecking.parse.PropositionalLogicParser.PropositionalLogicAnd;
+import me.paultristanwagner.satchecking.parse.PropositionalLogicParser.PropositionalLogicBiConditional;
+import me.paultristanwagner.satchecking.parse.PropositionalLogicParser.PropositionalLogicExpression;
+import me.paultristanwagner.satchecking.parse.PropositionalLogicParser.PropositionalLogicImplication;
+import me.paultristanwagner.satchecking.parse.PropositionalLogicParser.PropositionalLogicNegation;
+import me.paultristanwagner.satchecking.parse.PropositionalLogicParser.PropositionalLogicOr;
+import me.paultristanwagner.satchecking.parse.PropositionalLogicParser.PropositionalLogicVariable;
+import me.paultristanwagner.satchecking.sat.CNF;
+import me.paultristanwagner.satchecking.smt.TheoryCNF;
 import me.paultristanwagner.satchecking.smt.TheoryClause;
 import me.paultristanwagner.satchecking.theory.Constraint;
 import me.paultristanwagner.satchecking.theory.EqualityConstraint;
@@ -20,8 +31,12 @@ import java.util.List;
  * the declared logic and the optional {@code :status}). It does not run the solver itself; see
  * {@code command/impl/SmtLibCommand}.
  *
- * <p>Supported logics: QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF. Supported boolean structure is a CNF
- * fragment only (conjunctions of clauses, where a clause is a disjunction of positive atoms).
+ * <p>Supported logics: QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF. For the equality logics (QF_EQ,
+ * QF_UF, QF_EQUF) arbitrary boolean structure over equality atoms is supported (and/or/not/=>/xor/
+ * ite, including negated atoms and {@code distinct}); the formula is Tseitin-transformed and a
+ * {@link TheoryCNF} is returned via {@link SmtLibScript#getTheoryCNF()}. For the arithmetic logics
+ * (QF_LRA, QF_LIA) only a CNF fragment of positive atoms is supported (negation/strict inequalities
+ * are rejected) and the boolean skeleton is returned as {@link SmtLibScript#getClauses()}.
  *
  * @author Paul Tristan Wagner <paultristanwagner@gmail.com>
  */
@@ -34,16 +49,19 @@ public class SmtLibParser {
     private final String status; // "sat" | "unsat" | "unknown" | null
     private final List<TheoryClause<Constraint>> clauses;
     private final List<String> warnings;
+    private final TheoryCNF<Constraint> theoryCNF; // non-null for general boolean structure path
 
     public SmtLibScript(
         String logic,
         String status,
         List<TheoryClause<Constraint>> clauses,
-        List<String> warnings) {
+        List<String> warnings,
+        TheoryCNF<Constraint> theoryCNF) {
       this.logic = logic;
       this.status = status;
       this.clauses = clauses;
       this.warnings = warnings;
+      this.theoryCNF = theoryCNF;
     }
 
     public String getLogic() {
@@ -60,6 +78,15 @@ public class SmtLibParser {
 
     public List<String> getWarnings() {
       return warnings;
+    }
+
+    /**
+     * The prebuilt {@link TheoryCNF} for the general-boolean-structure path (equality logics), or
+     * {@code null} when the script was parsed via the CNF-fragment path (arithmetic logics), in
+     * which case {@link #getClauses()} carries the boolean skeleton.
+     */
+    public TheoryCNF<Constraint> getTheoryCNF() {
+      return theoryCNF;
     }
   }
 
@@ -124,6 +151,11 @@ public class SmtLibParser {
   private final List<TheoryClause<Constraint>> clauses = new ArrayList<>();
   private final List<String> warnings = new ArrayList<>();
 
+  // General boolean-structure path (equality logics only): one propositional formula per assert,
+  // over equality atoms canonicalized to their POSITIVE form. A fresh "a<i>" name per distinct atom.
+  private final List<PropositionalLogicExpression> assertedFormulas = new ArrayList<>();
+  private final BiMap<Constraint, String> atomNameMap = HashBiMap.create();
+
   public SmtLibParser(String input) {
     this.input = input;
     this.tokens = tokenize(input);
@@ -179,7 +211,25 @@ public class SmtLibParser {
       SExpr command = readSExpr();
       handleCommand(command);
     }
-    return new SmtLibScript(logicName, status, clauses, warnings);
+
+    TheoryCNF<Constraint> theoryCNF = null;
+    if (kind == Kind.EQUALITY || kind == Kind.UF) {
+      // Conjoin all asserted formulas. An empty assertion set is trivially satisfiable; we model it
+      // with an empty CNF (no clauses), which the SAT solver treats as SAT.
+      CNF cnf;
+      if (assertedFormulas.isEmpty()) {
+        cnf = new CNF(new ArrayList<>());
+      } else {
+        PropositionalLogicExpression conjunction =
+            assertedFormulas.size() == 1
+                ? assertedFormulas.get(0)
+                : new PropositionalLogicAnd(assertedFormulas);
+        cnf = PropositionalLogicParser.tseitin(conjunction);
+      }
+      theoryCNF = new TheoryCNF<>(cnf, atomNameMap);
+    }
+
+    return new SmtLibScript(logicName, status, clauses, warnings, theoryCNF);
   }
 
   private void handleCommand(SExpr command) {
@@ -267,7 +317,178 @@ public class SmtLibParser {
       throw err("assert expects exactly one formula", index);
     }
     SExpr formula = args.get(0);
-    addFormula(formula);
+    if (kind == Kind.EQUALITY || kind == Kind.UF) {
+      assertedFormulas.add(parseBooleanFormula(formula));
+    } else {
+      addFormula(formula);
+    }
+  }
+
+  // ---- general boolean structure (equality logics only) ---------------------
+
+  /**
+   * Parses an arbitrary boolean formula over equality atoms into a {@link
+   * PropositionalLogicExpression}. Leaves are equality atoms, each canonicalized to its POSITIVE
+   * form ({@code (= s t)}); {@code (distinct s t)} and {@code (not (= s t))} are represented as the
+   * boolean negation of the positive atom.
+   */
+  private PropositionalLogicExpression parseBooleanFormula(SExpr formula) {
+    if (formula.isAtom()) {
+      String v = formula.atom.value();
+      if (v.equals("true")) {
+        return tautology();
+      }
+      if (v.equals("false")) {
+        return new PropositionalLogicNegation(tautology());
+      }
+      throw err(
+          "expected a boolean formula; bare symbol '" + v + "' is not a boolean atom", formula.index);
+    }
+
+    String head = formula.head();
+    if (head == null) {
+      throw err("expected a boolean formula", formula.index);
+    }
+
+    switch (head) {
+      case "and" -> {
+        List<PropositionalLogicExpression> parts = booleanArgs(formula);
+        if (parts.isEmpty()) {
+          return tautology();
+        }
+        return PropositionalLogicAnd.and(parts);
+      }
+      case "or" -> {
+        List<PropositionalLogicExpression> parts = booleanArgs(formula);
+        if (parts.isEmpty()) {
+          return new PropositionalLogicNegation(tautology()); // empty disjunction = false
+        }
+        return PropositionalLogicOr.or(parts);
+      }
+      case "not" -> {
+        if (formula.list.size() != 2) {
+          throw err("'not' expects exactly one argument", formula.index);
+        }
+        return new PropositionalLogicNegation(parseBooleanFormula(formula.list.get(1)));
+      }
+      case "=>", "implies" -> {
+        List<PropositionalLogicExpression> parts = booleanArgs(formula);
+        if (parts.isEmpty()) {
+          throw err("'" + head + "' requires at least one argument", formula.index);
+        }
+        // Right-associative chained implication: a => b => c == a => (b => c).
+        PropositionalLogicExpression result = parts.get(parts.size() - 1);
+        for (int i = parts.size() - 2; i >= 0; i--) {
+          result = new PropositionalLogicImplication(parts.get(i), result);
+        }
+        return result;
+      }
+      case "xor" -> {
+        List<PropositionalLogicExpression> parts = booleanArgs(formula);
+        if (parts.isEmpty()) {
+          throw err("'xor' requires at least one argument", formula.index);
+        }
+        // xor chain as left-associative negated biconditionals.
+        PropositionalLogicExpression result = parts.get(0);
+        for (int i = 1; i < parts.size(); i++) {
+          result = new PropositionalLogicNegation(
+              new PropositionalLogicBiConditional(result, parts.get(i)));
+        }
+        return result;
+      }
+      case "=", "distinct" -> {
+        // '=' over boolean sub-formulas is a biconditional; but in this subset '=' is the equality
+        // predicate over (uninterpreted/sort) terms. Treat it as an atom.
+        return atomFormula(formula, head);
+      }
+      case "ite" -> {
+        // (ite a b c) == (or (and a b) (and (not a) c))
+        if (formula.list.size() != 4) {
+          throw err("'ite' expects exactly three arguments", formula.index);
+        }
+        PropositionalLogicExpression a = parseBooleanFormula(formula.list.get(1));
+        PropositionalLogicExpression b = parseBooleanFormula(formula.list.get(2));
+        PropositionalLogicExpression c = parseBooleanFormula(formula.list.get(3));
+        // 'a' may be reused; rebuild a fresh negation node for the else branch.
+        PropositionalLogicExpression notA = new PropositionalLogicNegation(parseBooleanFormula(formula.list.get(1)));
+        return PropositionalLogicOr.or(
+            PropositionalLogicAnd.and(a, b), PropositionalLogicAnd.and(notA, c));
+      }
+      default -> {
+        // Any other head is treated as a (positive) equality-style atom.
+        return atomFormula(formula, head);
+      }
+    }
+  }
+
+  private List<PropositionalLogicExpression> booleanArgs(SExpr formula) {
+    List<PropositionalLogicExpression> parts = new ArrayList<>();
+    for (int i = 1; i < formula.list.size(); i++) {
+      parts.add(parseBooleanFormula(formula.list.get(i)));
+    }
+    return parts;
+  }
+
+  /**
+   * Builds the propositional representation of an equality atom. {@code (= s t)} -> positive atom
+   * variable; {@code (distinct a b ...)} -> conjunction of pairwise {@code not (= ai aj)}.
+   */
+  private PropositionalLogicExpression atomFormula(SExpr atom, String head) {
+    if (head.equals("distinct")) {
+      List<SExpr> argExprs = atom.list.subList(1, atom.list.size());
+      if (argExprs.size() < 2) {
+        throw err("'distinct' requires at least two arguments", atom.index);
+      }
+      List<PropositionalLogicExpression> negEqs = new ArrayList<>();
+      for (int i = 0; i < argExprs.size(); i++) {
+        for (int j = i + 1; j < argExprs.size(); j++) {
+          Constraint eq = makeEquality(argExprs.get(i), argExprs.get(j), atom.index);
+          negEqs.add(new PropositionalLogicNegation(atomVariable(eq)));
+        }
+      }
+      return negEqs.size() == 1 ? negEqs.get(0) : PropositionalLogicAnd.and(negEqs);
+    }
+
+    if (!head.equals("=")) {
+      throw err("unsupported equality predicate '" + head + "'", atom.index);
+    }
+    if (atom.list.size() != 3) {
+      throw err("'=' expects exactly two arguments in this subset", atom.index);
+    }
+    Constraint eq = makeEquality(atom.list.get(1), atom.list.get(2), atom.index);
+    return atomVariable(eq);
+  }
+
+  /** Creates the POSITIVE equality constraint for the current equality logic. */
+  private Constraint makeEquality(SExpr leftExpr, SExpr rightExpr, int index) {
+    if (kind == Kind.EQUALITY) {
+      String left = requireVariable(leftExpr);
+      String right = requireVariable(rightExpr);
+      return new EqualityConstraint(left, right, true);
+    } else { // UF
+      Function left = parseFunctionTerm(leftExpr);
+      Function right = parseFunctionTerm(rightExpr);
+      return new EqualityFunctionConstraint(left, right, true);
+    }
+  }
+
+  /** Returns the propositional variable naming the given (positive) atom, allocating "a<i>" once. */
+  private PropositionalLogicVariable atomVariable(Constraint atom) {
+    String name = atomNameMap.get(atom);
+    if (name == null) {
+      name = "a" + atomNameMap.size();
+      atomNameMap.put(atom, name);
+    }
+    return new PropositionalLogicVariable(name);
+  }
+
+  /**
+   * A propositional tautology used to encode {@code true}. Uses a dedicated reserved atom name that
+   * never collides with equality atoms ("a*") or Tseitin helpers ("h*"): {@code (top | ~top)}.
+   */
+  private PropositionalLogicExpression tautology() {
+    PropositionalLogicVariable top = new PropositionalLogicVariable("__top");
+    return PropositionalLogicOr.or(top, new PropositionalLogicNegation(top));
   }
 
   /** Adds the clauses produced by one asserted formula (CNF fragment). */

--- a/src/main/java/me/paultristanwagner/satchecking/smt/TheoryCNF.java
+++ b/src/main/java/me/paultristanwagner/satchecking/smt/TheoryCNF.java
@@ -56,6 +56,27 @@ public class TheoryCNF<T extends Constraint> {
     this.booleanStructure = new CNF(booleanClauses);
   }
 
+  /**
+   * Builds a {@code TheoryCNF} directly from a prebuilt boolean structure and an
+   * atom-to-name mapping. Used by the SMT-LIB front-end for the equality logics, where the boolean
+   * skeleton is produced by Tseitin transformation of an arbitrary boolean formula (including
+   * negated atoms) rather than a CNF fragment. The {@code clauses} lists are left empty; the lazy
+   * SMT loop only consumes {@link #getBooleanStructure()} and {@link #getConstraintLiteralMap()}.
+   */
+  public TheoryCNF(CNF booleanStructure, BiMap<T, String> constraintNames) {
+    this.initialClauses = new ArrayList<>();
+    this.clauses = new ArrayList<>();
+    this.constraints = new ArrayList<>(constraintNames.keySet());
+
+    this.constraintNameMap = constraintNames;
+    this.constraintLiteralMap = HashBiMap.create();
+    for (var entry : constraintNames.entrySet()) {
+      this.constraintLiteralMap.put(entry.getKey(), new Literal(entry.getValue()));
+    }
+
+    this.booleanStructure = booleanStructure;
+  }
+
   public static <T extends Constraint> TheoryCNF<T> parse(String string) {
     throw new UnsupportedOperationException();
   }

--- a/src/main/java/me/paultristanwagner/satchecking/smt/solver/FullLazySMTSolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/smt/solver/FullLazySMTSolver.java
@@ -140,8 +140,13 @@ public class FullLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
         }
       }
 
-      Clause clause = new Clause(literals);
-      cnf.getBooleanStructure().learnClause(clause);
+      // Guard: if every explanation constraint was unmapped (e.g. a theory returned only derived
+      // helper constraints), do NOT learn an empty clause — that would falsely force UNSAT. The
+      // current model is still excluded by nextModel()'s built-in blocking, so termination holds.
+      if (!literals.isEmpty()) {
+        Clause clause = new Clause(literals);
+        cnf.getBooleanStructure().learnClause(clause);
+      }
     }
 
     if (objectivePresent && foundOptimizationSolution) {

--- a/src/main/java/me/paultristanwagner/satchecking/smt/solver/FullLazySMTSolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/smt/solver/FullLazySMTSolver.java
@@ -33,19 +33,29 @@ public class FullLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
 
     Assignment assignment;
     while ((assignment = satSolver.nextModel()) != null) {
-      List<Literal> trueLiterals = assignment.getTrueLiterals();
-
       theorySolver.clear();
 
+      // Build the selected constraints by inspecting the assignment of EVERY atom literal. A
+      // TRUE-assigned atom is asserted as-is; a FALSE-assigned atom is asserted as its negation
+      // (issue #9) when the constraint is negatable (exact for equality logics), otherwise skipped
+      // to preserve the sound positive-only behavior for theories without exact atom negation.
       Set<C> selectedConstraints = new HashSet<>();
-      for (Literal trueLiteral : trueLiterals) {
-        if(!cnf.getConstraintLiteralMap().inverse().containsKey(trueLiteral.getName())) {
+      for (var entry : cnf.getConstraintLiteralMap().entrySet()) {
+        C constraint = entry.getKey();
+        String name = entry.getValue();
+
+        if (!assignment.assigns(new Literal(name))) {
           continue;
         }
 
-        C constraint = cnf.getConstraintLiteralMap().inverse().get(trueLiteral.getName());
-
-        selectedConstraints.add(constraint);
+        boolean value = assignment.getValue(name);
+        if (value) {
+          selectedConstraints.add(constraint);
+        } else if (constraint.isNegatable()) {
+          @SuppressWarnings("unchecked")
+          C negated = (C) constraint.negate();
+          selectedConstraints.add(negated);
+        }
       }
 
       theorySolver.load(selectedConstraints);
@@ -98,13 +108,36 @@ public class FullLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
         return SMTResult.satisfiable(theoryResult.getSolution());
       }
 
-      // Exclude explanation
+      // Exclude explanation. The explanation may reference negated atoms (constraints produced by
+      // negate() that are NOT keys of the constraint map). For each explanation constraint we must
+      // recover the literal of the POSITIVE atom in the map and use the correct polarity:
+      //  - constraint present in map  -> it was assigned TRUE -> block with its negative literal.
+      //  - constraint is a negation of a mapped atom -> the atom was assigned FALSE -> block with
+      //    its positive literal.
+      // Mapping to neither must not happen for the equality logics; we log and skip to avoid
+      // producing a Literal(null) that would corrupt the blocking clause and break termination.
       Set<C> explanation = theoryResult.getExplanation();
 
       List<Literal> literals = new ArrayList<>();
       for (C constraint : explanation) {
         String literalName = cnf.getConstraintLiteralMap().get(constraint);
-        literals.add(new Literal(literalName).not());
+        if (literalName != null) {
+          literals.add(new Literal(literalName).not());
+        } else if (constraint.isNegatable()) {
+          @SuppressWarnings("unchecked")
+          C positive = (C) constraint.negate();
+          String positiveName = cnf.getConstraintLiteralMap().get(positive);
+          if (positiveName != null) {
+            literals.add(new Literal(positiveName));
+          } else {
+            System.err.println(
+                "FullLazySMTSolver: explanation constraint not in atom map, skipping: "
+                    + constraint);
+          }
+        } else {
+          System.err.println(
+              "FullLazySMTSolver: explanation constraint not in atom map, skipping: " + constraint);
+        }
       }
 
       Clause clause = new Clause(literals);

--- a/src/main/java/me/paultristanwagner/satchecking/smt/solver/LessLazySMTSolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/smt/solver/LessLazySMTSolver.java
@@ -31,29 +31,30 @@ public class LessLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
     Number bestOptimum = null;
     VariableAssignment bestSolution = null;
 
-    int lastLevel = 0;
     PartialAssignment assignment;
     while ((assignment = satSolver.nextPartialAssignment()) != null) {
-      int newLevel = assignment.getDecisionLevel();
-      if (newLevel < lastLevel) {
-        theorySolver.clear();
+      // Reload the theory state from the full current partial assignment on every step. This is
+      // simpler than incremental push/pop and, crucially, correctly handles (a) Tseitin helper
+      // literals and other non-atom literals (skipped) and (b) FALSE-assigned atoms, which for the
+      // equality logic are asserted as their exact negation (issue #9). Atoms are canonicalized to
+      // their POSITIVE form in the atom map, so a false atom contributes constraint.negate().
+      theorySolver.clear();
+      for (var entry : cnf.getConstraintLiteralMap().entrySet()) {
+        C constraint = entry.getKey();
+        String name = entry.getValue();
 
-        // Re-adding all up-until the new level
-        // todo: Even better: just pop the constraint from undone levels
-        for (Literal trueLiteral : assignment.getTrueLiterals()) {
-          C constraint = cnf.getConstraintLiteralMap().inverse().get(trueLiteral.getName());
-
-          theorySolver.addConstraint(constraint);
+        if (!assignment.assigns(new Literal(name))) {
+          continue;
         }
-      } else {
-        List<Literal> trueLiteralsOnCurrentLevel = assignment.getTrueLiteralsOnCurrentLevel();
-        for (Literal trueLiteral : trueLiteralsOnCurrentLevel) {
-          C constraint = cnf.getConstraintLiteralMap().inverse().get(trueLiteral.getName());
 
+        if (assignment.getValue(name)) {
           theorySolver.addConstraint(constraint);
+        } else if (constraint.isNegatable()) {
+          @SuppressWarnings("unchecked")
+          C negated = (C) constraint.negate();
+          theorySolver.addConstraint(negated);
         }
       }
-      lastLevel = newLevel;
 
       TheoryResult<C> theoryResult = theorySolver.solve();
       if (theoryResult.isUnknown()) { // If the theory solver is unknown, we can't do anything
@@ -94,8 +95,6 @@ public class LessLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
         if (!resolvable) {
           break;
         }
-        theorySolver.clear();
-        lastLevel = 0;
       } else if (theoryResult.isSatisfiable()) {
         if (assignment.isComplete()) {
           return SMTResult.satisfiable(theoryResult.getSolution());
@@ -103,10 +102,29 @@ public class LessLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
       } else {
         Set<C> explanation = theoryResult.getExplanation();
 
+        // The explanation may contain negated atoms (negate()'d constraints not present as map
+        // keys). Recover the positive atom literal and use the correct polarity (see #9).
         List<Literal> literals = new ArrayList<>();
         for (C equalityConstraint : explanation) {
           String literalName = cnf.getConstraintLiteralMap().get(equalityConstraint);
-          literals.add(new Literal(literalName).not());
+          if (literalName != null) {
+            literals.add(new Literal(literalName).not());
+          } else if (equalityConstraint.isNegatable()) {
+            @SuppressWarnings("unchecked")
+            C positive = (C) equalityConstraint.negate();
+            String positiveName = cnf.getConstraintLiteralMap().get(positive);
+            if (positiveName != null) {
+              literals.add(new Literal(positiveName));
+            } else {
+              System.err.println(
+                  "LessLazySMTSolver: explanation constraint not in atom map, skipping: "
+                      + equalityConstraint);
+            }
+          } else {
+            System.err.println(
+                "LessLazySMTSolver: explanation constraint not in atom map, skipping: "
+                    + equalityConstraint);
+          }
         }
 
         Clause clause = new Clause(literals);

--- a/src/main/java/me/paultristanwagner/satchecking/theory/Constraint.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/Constraint.java
@@ -1,4 +1,21 @@
 package me.paultristanwagner.satchecking.theory;
 
 public interface Constraint {
+
+  /**
+   * Whether this constraint has an exact boolean negation expressible as another {@link Constraint}.
+   * Defaults to {@code false}; theories whose atom negation is exact (e.g. equality logics) override
+   * this to {@code true}.
+   */
+  default boolean isNegatable() {
+    return false;
+  }
+
+  /**
+   * Returns the constraint representing the boolean negation of this atom. Only valid when
+   * {@link #isNegatable()} returns {@code true}.
+   */
+  default Constraint negate() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/src/main/java/me/paultristanwagner/satchecking/theory/EqualityConstraint.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/EqualityConstraint.java
@@ -1,5 +1,7 @@
 package me.paultristanwagner.satchecking.theory;
 
+import java.util.Objects;
+
 /**
  * @author Paul Tristan Wagner <paultristanwagner@gmail.com>
  * @version 1.0
@@ -26,6 +28,31 @@ public class EqualityConstraint implements Constraint {
 
   public boolean areEqual() {
     return equal;
+  }
+
+  @Override
+  public boolean isNegatable() {
+    return true;
+  }
+
+  @Override
+  public Constraint negate() {
+    return new EqualityConstraint(left, right, !equal);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EqualityConstraint that = (EqualityConstraint) o;
+    return equal == that.equal
+        && Objects.equals(left, that.left)
+        && Objects.equals(right, that.right);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(left, right, equal);
   }
 
   @Override

--- a/src/main/java/me/paultristanwagner/satchecking/theory/EqualityFunctionConstraint.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/EqualityFunctionConstraint.java
@@ -27,6 +27,16 @@ public class EqualityFunctionConstraint implements Constraint {
   }
 
   @Override
+  public boolean isNegatable() {
+    return true;
+  }
+
+  @Override
+  public Constraint negate() {
+    return new EqualityFunctionConstraint(left, right, !equal);
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;

--- a/src/test/java/SmtLibBooleanStructureTest.java
+++ b/src/test/java/SmtLibBooleanStructureTest.java
@@ -1,0 +1,91 @@
+import me.paultristanwagner.satchecking.command.impl.SmtLibCommand;
+import me.paultristanwagner.satchecking.command.impl.SmtLibCommand.Verdict;
+import me.paultristanwagner.satchecking.parse.SyntaxError;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for general boolean structure (and/or/not/=>/ite/xor) over equality atoms in the equality
+ * logics (QF_EQ, QF_UF/QF_EQUF). Covers negated-atom handling (issue #9) and the boolean-structure
+ * increment of #33.
+ *
+ * @author Paul Tristan Wagner <paultristanwagner@gmail.com>
+ */
+public class SmtLibBooleanStructureTest {
+
+  private static Verdict run(String script) {
+    return SmtLibCommand.runScript(script, false);
+  }
+
+  @Test
+  public void testQfUfCongruenceUnderNegation() {
+    // a = b implies f(a) = f(b); asserting f(a) != f(b) is unsat by congruence.
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_UF)(declare-sort U 0)(declare-const a U)(declare-const b U)"
+                + "(declare-fun f (U) U)(assert (= a b))(assert (not (= (f a) (f b))))(check-sat)"));
+  }
+
+  @Test
+  public void testQfEqOrWithNegatedAtom() {
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_EQ)(declare-const a U)(declare-const b U)(declare-const c U)"
+                + "(assert (or (= a b) (= b c)))(assert (not (= a c)))(check-sat)"));
+  }
+
+  @Test
+  public void testQfEqPropositionalContradiction() {
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_EQ)(declare-const a U)(declare-const b U)"
+                + "(assert (and (= a b) (not (= a b))))(check-sat)"));
+  }
+
+  @Test
+  public void testQfUfImplication() {
+    // (= a b) => (= b c), (= a b), (not (= b c)) is unsat.
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_UF)(declare-sort U 0)(declare-const a U)(declare-const b U)"
+                + "(declare-const c U)(assert (=> (= a b) (= b c)))(assert (= a b))"
+                + "(assert (not (= b c)))(check-sat)"));
+  }
+
+  @Test
+  public void testQfUfDistinctUnsat() {
+    // distinct over three terms is consistent only if all are in different classes; forcing two
+    // equal with a chain makes it unsat.
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_UF)(declare-sort U 0)(declare-const a U)(declare-const b U)"
+                + "(declare-const c U)(assert (distinct a b c))(assert (= a b))(check-sat)"));
+  }
+
+  @Test
+  public void testQfUfIteSat() {
+    // (ite (= a b) (= b c) (= a c)) with (= a b) true forces (= b c).
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_UF)(declare-sort U 0)(declare-const a U)(declare-const b U)"
+                + "(declare-const c U)(assert (ite (= a b) (= b c) (= a c)))(check-sat)"));
+  }
+
+  @Test
+  public void testArithmeticStillRejectsStrictAndNegation() {
+    assertThrows(
+        SyntaxError.class,
+        () -> run("(set-logic QF_LRA)(declare-const x Real)(assert (< x 5))(check-sat)"));
+    assertThrows(
+        SyntaxError.class,
+        () ->
+            run("(set-logic QF_LRA)(declare-const x Real)(assert (not (<= x 5)))(check-sat)"));
+  }
+}


### PR DESCRIPTION
## #9 (+ #33 boolean structure) — general boolean structure for the equality logics, with sound negated-atom handling

Enables the SMT-LIB front-end to handle arbitrary boolean structure (`and`/`or`/`not`/`=>`/`ite`/`xor`) for **QF_EQ / QF_UF / QF_EQUF**, and makes the lazy loop assert the negation of false-assigned atoms (**#9**) — sound here because equality-atom negation is exact (`distinct`).

### How
- `Constraint.negate()/isNegatable()` (defaults) + exact impls for `EqualityFunctionConstraint`/`EqualityConstraint` (flip `equal`); added missing `equals`/`hashCode` to `EqualityConstraint`.
- New `TheoryCNF(CNF, BiMap)` constructor accepting a prebuilt boolean skeleton with **negated** literals.
- `SmtLibParser`: equality atoms canonicalized to positive `(=)`; `not`/`distinct` become boolean negation; the formula is Tseitin-transformed (reusing `PropositionalLogicParser.tseitin`) into a CNF over atom literals (`a*` names, no clash with Tseitin `h*` helpers). Arithmetic logics keep the CNF-fragment path and still reject strict `<`/`>` and negation.
- `FullLazySMTSolver`: builds the theory query from **all** atoms (true → atom, false → `negate()`); maps explanations back to the correct literal polarity (handles negated atoms — avoids the `Literal(null)`/non-termination trap); guards against learning an empty clause.
- `LessLazySMTSolver` reworked to reload theory state from the full assignment each step (QF_EQ path).

### Verification — real SMT-LIB benchmarks (SMT-LIB 2025 release, `QF_UF/eq_diamond`)
Went from **0% parseable → solving real equality-logic benchmarks**. On the 40 smallest QF_UF files (6 s/file): **MATCH_UNSAT 6, TIMEOUT 26, PARSE_ERROR 8, MISMATCH 0**.
- **0 wrong verdicts** — soundness gate held.
- Timeouts are the lazy loop's eager full-model enumeration (exponential on eq_diamond) — a performance/architecture limit, not soundness.
- The 8 parse errors are a different family (`2018-Goel-hwbench`) using `define-fun`/`let` (unsupported).
- Full regression suite still green (differential SAT 0/0/0; #10/#14/#20/#36 intact; QF_LRA SAT/UNSAT/objective unchanged).

### Scope / still open
- Equality logics only. Arithmetic negation + strict inequalities (QF_LRA/LIA) remain rejected — they need a strict-bound representation in `LinearConstraint` (separate gap). QF_BV/QF_NRA boolean negation untouched.
- The eq_diamond timeouts motivate a follow-up on the lazy loop's eager enumeration (DPLL(T)-style theory propagation), and `define-fun`/`let` support.

Advances #9 (equality logics) and #33 (boolean structure).
