### PR TITLE
QF_LRA/QF_LIA: strict inequalities (δ-rational) + arithmetic boolean structure + let

### DIFF
--- a/src/main/java/me/paultristanwagner/satchecking/parse/LinearConstraintLexer.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/LinearConstraintLexer.java
@@ -13,6 +13,8 @@ public class LinearConstraintLexer extends Lexer {
         EQUALS,
         LOWER_EQUALS,
         GREATER_EQUALS,
+        LESS_THAN,
+        GREATER_THAN,
         LPAREN,
         RPAREN
     );

--- a/src/main/java/me/paultristanwagner/satchecking/parse/LinearConstraintParser.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/LinearConstraintParser.java
@@ -74,16 +74,22 @@ public class LinearConstraintParser implements Parser<LinearConstraint> {
   }
 
   private static Bound BOUND(Lexer lexer) {
-    lexer.requireEither(EQUALS, LOWER_EQUALS, GREATER_EQUALS);
+    lexer.requireEither(EQUALS, LOWER_EQUALS, GREATER_EQUALS, LESS_THAN, GREATER_THAN);
     if (lexer.canConsume(EQUALS)) {
       lexer.consume(EQUALS);
       return EQUAL;
     } else if (lexer.canConsume(LOWER_EQUALS)) {
       lexer.consume(LOWER_EQUALS);
       return LESS_EQUALS;
-    } else {
+    } else if (lexer.canConsume(GREATER_EQUALS)) {
       lexer.consume(GREATER_EQUALS);
       return Bound.GREATER_EQUALS;
+    } else if (lexer.canConsume(LESS_THAN)) {
+      lexer.consume(LESS_THAN);
+      return Bound.LESS;
+    } else {
+      lexer.consume(GREATER_THAN);
+      return Bound.GREATER;
     }
   }
 }

--- a/src/main/java/me/paultristanwagner/satchecking/parse/SmtLibParser.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/SmtLibParser.java
@@ -20,8 +20,12 @@ import me.paultristanwagner.satchecking.theory.LinearConstraint;
 import me.paultristanwagner.satchecking.theory.LinearTerm;
 import me.paultristanwagner.satchecking.theory.arithmetic.Number;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Parser for a subset of SMT-LIB 2.6 scripts.
@@ -31,12 +35,18 @@ import java.util.List;
  * the declared logic and the optional {@code :status}). It does not run the solver itself; see
  * {@code command/impl/SmtLibCommand}.
  *
- * <p>Supported logics: QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF. For the equality logics (QF_EQ,
- * QF_UF, QF_EQUF) arbitrary boolean structure over equality atoms is supported (and/or/not/=>/xor/
- * ite, including negated atoms and {@code distinct}); the formula is Tseitin-transformed and a
- * {@link TheoryCNF} is returned via {@link SmtLibScript#getTheoryCNF()}. For the arithmetic logics
- * (QF_LRA, QF_LIA) only a CNF fragment of positive atoms is supported (negation/strict inequalities
- * are rejected) and the boolean skeleton is returned as {@link SmtLibScript#getClauses()}.
+ * <p>Supported logics: QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF. For ALL of these logics arbitrary
+ * boolean structure over the theory atoms is supported (and/or/not/=>/xor/ite/true/false, including
+ * negated atoms, {@code distinct} and {@code let} bindings); the conjunction of asserted formulas is
+ * Tseitin-transformed and a {@link TheoryCNF} is returned via {@link SmtLibScript#getTheoryCNF()}.
+ *
+ * <p>Equality logics (QF_EQ, QF_UF, QF_EQUF) build {@code EqualityConstraint}/{@code
+ * EqualityFunctionConstraint} leaves. Arithmetic logics (QF_LRA, QF_LIA) build {@link
+ * LinearConstraint} leaves over {@code <=}, {@code >=}, {@code <}, {@code >}; an {@code (= s t)}
+ * atom is eliminated by splitting into {@code (and (<= s t) (>= s t))} so that every atom's negation
+ * is a single (strict/non-strict) inequality, and {@code (distinct s t)} / {@code (not (= s t))}
+ * become disjunctions of strict atoms. Only linear arithmetic terms are accepted; nonlinear products
+ * are rejected.
  *
  * @author Paul Tristan Wagner <paultristanwagner@gmail.com>
  */
@@ -156,6 +166,21 @@ public class SmtLibParser {
   private final List<PropositionalLogicExpression> assertedFormulas = new ArrayList<>();
   private final BiMap<Constraint, String> atomNameMap = HashBiMap.create();
 
+  // Scoped 'let' environment. Each frame maps a bound symbol to its parsed value. A value is either
+  // a parsed LinearTerm (term-sorted binding) or a parsed PropositionalLogicExpression (formula).
+  // Frames are pushed for the body of a let and popped on exit; lookup scans from innermost out, so
+  // shadowing and nesting work naturally.
+  private final Deque<Map<String, Object>> letScopes = new ArrayDeque<>();
+
+  private Object lookupLet(String symbol) {
+    for (Map<String, Object> frame : letScopes) {
+      if (frame.containsKey(symbol)) {
+        return frame.get(symbol);
+      }
+    }
+    return null;
+  }
+
   public SmtLibParser(String input) {
     this.input = input;
     this.tokens = tokenize(input);
@@ -212,22 +237,20 @@ public class SmtLibParser {
       handleCommand(command);
     }
 
-    TheoryCNF<Constraint> theoryCNF = null;
-    if (kind == Kind.EQUALITY || kind == Kind.UF) {
-      // Conjoin all asserted formulas. An empty assertion set is trivially satisfiable; we model it
-      // with an empty CNF (no clauses), which the SAT solver treats as SAT.
-      CNF cnf;
-      if (assertedFormulas.isEmpty()) {
-        cnf = new CNF(new ArrayList<>());
-      } else {
-        PropositionalLogicExpression conjunction =
-            assertedFormulas.size() == 1
-                ? assertedFormulas.get(0)
-                : new PropositionalLogicAnd(assertedFormulas);
-        cnf = PropositionalLogicParser.tseitin(conjunction);
-      }
-      theoryCNF = new TheoryCNF<>(cnf, atomNameMap);
+    // All supported logics use the general boolean-structure path: conjoin all asserted formulas,
+    // Tseitin-transform and build a TheoryCNF from the (CNF, atom-name) mapping. An empty assertion
+    // set is trivially satisfiable; we model it with an empty CNF (no clauses), treated as SAT.
+    CNF cnf;
+    if (assertedFormulas.isEmpty()) {
+      cnf = new CNF(new ArrayList<>());
+    } else {
+      PropositionalLogicExpression conjunction =
+          assertedFormulas.size() == 1
+              ? assertedFormulas.get(0)
+              : new PropositionalLogicAnd(assertedFormulas);
+      cnf = PropositionalLogicParser.tseitin(conjunction);
     }
+    TheoryCNF<Constraint> theoryCNF = new TheoryCNF<>(cnf, atomNameMap);
 
     return new SmtLibScript(logicName, status, clauses, warnings, theoryCNF);
   }
@@ -317,20 +340,17 @@ public class SmtLibParser {
       throw err("assert expects exactly one formula", index);
     }
     SExpr formula = args.get(0);
-    if (kind == Kind.EQUALITY || kind == Kind.UF) {
-      assertedFormulas.add(parseBooleanFormula(formula));
-    } else {
-      addFormula(formula);
-    }
+    assertedFormulas.add(parseBooleanFormula(formula));
   }
 
   // ---- general boolean structure (equality logics only) ---------------------
 
   /**
-   * Parses an arbitrary boolean formula over equality atoms into a {@link
-   * PropositionalLogicExpression}. Leaves are equality atoms, each canonicalized to its POSITIVE
-   * form ({@code (= s t)}); {@code (distinct s t)} and {@code (not (= s t))} are represented as the
-   * boolean negation of the positive atom.
+   * Parses an arbitrary boolean formula over theory atoms into a {@link PropositionalLogicExpression}.
+   * Leaves are theory atoms (equality atoms for the equality logics, {@link LinearConstraint}
+   * inequalities for the arithmetic logics). {@code (distinct ...)} and {@code (not ...)} are
+   * represented as boolean structure over the positive atoms, and {@code let} bindings are resolved
+   * against the scoped environment.
    */
   private PropositionalLogicExpression parseBooleanFormula(SExpr formula) {
     if (formula.isAtom()) {
@@ -340,6 +360,15 @@ public class SmtLibParser {
       }
       if (v.equals("false")) {
         return new PropositionalLogicNegation(tautology());
+      }
+      // A let-bound symbol used where a formula is expected resolves to its formula.
+      Object bound = lookupLet(v);
+      if (bound instanceof PropositionalLogicExpression expr) {
+        return expr;
+      }
+      if (bound instanceof LinearTerm) {
+        throw err(
+            "let-bound symbol '" + v + "' is a term but is used as a boolean formula", formula.index);
       }
       throw err(
           "expected a boolean formula; bare symbol '" + v + "' is not a boolean atom", formula.index);
@@ -351,6 +380,9 @@ public class SmtLibParser {
     }
 
     switch (head) {
+      case "let" -> {
+        return parseLetFormula(formula);
+      }
       case "and" -> {
         List<PropositionalLogicExpression> parts = booleanArgs(formula);
         if (parts.isEmpty()) {
@@ -396,9 +428,9 @@ public class SmtLibParser {
         }
         return result;
       }
-      case "=", "distinct" -> {
-        // '=' over boolean sub-formulas is a biconditional; but in this subset '=' is the equality
-        // predicate over (uninterpreted/sort) terms. Treat it as an atom.
+      case "=", "distinct", "<=", ">=", "<", ">" -> {
+        // '=' over boolean sub-formulas would be a biconditional; in this subset '=' is the equality/
+        // arithmetic predicate over terms. Treat it (and the inequality predicates) as an atom.
         return atomFormula(formula, head);
       }
       case "ite" -> {
@@ -430,10 +462,21 @@ public class SmtLibParser {
   }
 
   /**
+   * Builds the propositional representation of a theory atom. Dispatches to the arithmetic-specific
+   * handling for the arithmetic logics and to the equality handling otherwise.
+   */
+  private PropositionalLogicExpression atomFormula(SExpr atom, String head) {
+    if (kind == Kind.ARITHMETIC) {
+      return arithmeticAtomFormula(atom, head);
+    }
+    return equalityAtomFormula(atom, head);
+  }
+
+  /**
    * Builds the propositional representation of an equality atom. {@code (= s t)} -> positive atom
    * variable; {@code (distinct a b ...)} -> conjunction of pairwise {@code not (= ai aj)}.
    */
-  private PropositionalLogicExpression atomFormula(SExpr atom, String head) {
+  private PropositionalLogicExpression equalityAtomFormula(SExpr atom, String head) {
     if (head.equals("distinct")) {
       List<SExpr> argExprs = atom.list.subList(1, atom.list.size());
       if (argExprs.size() < 2) {
@@ -457,6 +500,164 @@ public class SmtLibParser {
     }
     Constraint eq = makeEquality(atom.list.get(1), atom.list.get(2), atom.index);
     return atomVariable(eq);
+  }
+
+  /**
+   * Builds the propositional representation of an arithmetic atom over {@link LinearConstraint}
+   * leaves. {@code <=}, {@code >=}, {@code <}, {@code >} become single inequality atoms; {@code (= s
+   * t)} is eliminated into {@code (and (<= s t) (>= s t))}; {@code (distinct s1 .. sn)} becomes the
+   * conjunction over pairs of {@code (or (< si sj) (> si sj))}. No EQUAL constraint is ever created,
+   * so every atom's negation is a single strict/non-strict inequality (see {@link
+   * LinearConstraint#negate()}).
+   */
+  private PropositionalLogicExpression arithmeticAtomFormula(SExpr atom, String head) {
+    switch (head) {
+      case "<=", ">=", "<", ">" -> {
+        if (atom.list.size() != 3) {
+          throw err("'" + head + "' expects exactly two arguments in this subset", atom.index);
+        }
+        LinearTerm lhs = parseLinearTerm(atom.list.get(1));
+        LinearTerm rhs = parseLinearTerm(atom.list.get(2));
+        LinearConstraint constraint =
+            switch (head) {
+              case "<=" -> LinearConstraint.lessThanOrEqual(lhs, rhs);
+              case ">=" -> LinearConstraint.greaterThanOrEqual(lhs, rhs);
+              case "<" -> LinearConstraint.lessThan(lhs, rhs);
+              default -> LinearConstraint.greaterThan(lhs, rhs);
+            };
+        return atomVariable(constraint);
+      }
+      case "=" -> {
+        if (atom.list.size() != 3) {
+          throw err("'=' expects exactly two arguments in this subset", atom.index);
+        }
+        return arithmeticEquality(atom.list.get(1), atom.list.get(2));
+      }
+      case "distinct" -> {
+        List<SExpr> argExprs = atom.list.subList(1, atom.list.size());
+        if (argExprs.size() < 2) {
+          throw err("'distinct' requires at least two arguments", atom.index);
+        }
+        List<PropositionalLogicExpression> parts = new ArrayList<>();
+        for (int i = 0; i < argExprs.size(); i++) {
+          for (int j = i + 1; j < argExprs.size(); j++) {
+            // si != sj  <=>  (si < sj) or (si > sj)
+            LinearTerm a = parseLinearTerm(argExprs.get(i));
+            LinearTerm b = parseLinearTerm(argExprs.get(j));
+            PropositionalLogicExpression lt =
+                atomVariable(LinearConstraint.lessThan(new LinearTerm(a), new LinearTerm(b)));
+            PropositionalLogicExpression gt =
+                atomVariable(LinearConstraint.greaterThan(new LinearTerm(a), new LinearTerm(b)));
+            parts.add(PropositionalLogicOr.or(lt, gt));
+          }
+        }
+        return parts.size() == 1 ? parts.get(0) : PropositionalLogicAnd.and(parts);
+      }
+      default -> throw err("unsupported arithmetic predicate '" + head + "'", atom.index);
+    }
+  }
+
+  /** Splits {@code (= s t)} into {@code (and (<= s t) (>= s t))} at the propositional level. */
+  private PropositionalLogicExpression arithmeticEquality(SExpr leftExpr, SExpr rightExpr) {
+    LinearTerm lhs = parseLinearTerm(leftExpr);
+    LinearTerm rhs = parseLinearTerm(rightExpr);
+    PropositionalLogicExpression le =
+        atomVariable(LinearConstraint.lessThanOrEqual(new LinearTerm(lhs), new LinearTerm(rhs)));
+    PropositionalLogicExpression ge =
+        atomVariable(LinearConstraint.greaterThanOrEqual(new LinearTerm(lhs), new LinearTerm(rhs)));
+    return PropositionalLogicAnd.and(le, ge);
+  }
+
+  // ---- let bindings ---------------------------------------------------------
+
+  /**
+   * Parses {@code (let ((v1 e1) ... (vn en)) body)} as a boolean formula. The bound expressions are
+   * evaluated in the OUTER scope (parallel binding), then a fresh frame is pushed for the body.
+   */
+  private PropositionalLogicExpression parseLetFormula(SExpr formula) {
+    Map<String, Object> frame = evaluateLetBindings(formula);
+    letScopes.push(frame);
+    try {
+      return parseBooleanFormula(formula.list.get(2));
+    } finally {
+      letScopes.pop();
+    }
+  }
+
+  /**
+   * Evaluates the binding list of a {@code let} in the current (outer) scope and returns the new
+   * frame. Each bound expression is lazily classified: it is stored as a {@link LinearTerm} when it
+   * parses as an arithmetic term, otherwise as a {@link PropositionalLogicExpression}. We try the
+   * term interpretation first only for the arithmetic logics; for equality logics bindings are
+   * always formulas.
+   */
+  private Map<String, Object> evaluateLetBindings(SExpr formula) {
+    if (formula.list.size() != 3) {
+      throw err("'let' expects a binding list and a body", formula.index);
+    }
+    SExpr bindings = formula.list.get(1);
+    if (!bindings.isList()) {
+      throw err("'let' bindings must be a list", bindings.index);
+    }
+    Map<String, Object> frame = new HashMap<>();
+    for (SExpr binding : bindings.list) {
+      if (!binding.isList() || binding.list.size() != 2 || !binding.list.get(0).isAtom()) {
+        throw err("malformed 'let' binding (expected (symbol value))", binding.index);
+      }
+      String name = binding.list.get(0).atom.value();
+      SExpr valueExpr = binding.list.get(1);
+      frame.put(name, evaluateLetValue(valueExpr));
+    }
+    return frame;
+  }
+
+  /**
+   * Evaluates a let-bound value in the current scope. For arithmetic logics we attempt to parse it
+   * as a linear term first (so that {@code (let ((s (+ x y))) ...)} works); if that fails it is a
+   * boolean formula. For equality logics it is always a boolean formula.
+   */
+  private Object evaluateLetValue(SExpr valueExpr) {
+    if (kind == Kind.ARITHMETIC && looksLikeArithmeticTerm(valueExpr)) {
+      return parseLinearTerm(valueExpr);
+    }
+    return parseBooleanFormula(valueExpr);
+  }
+
+  /**
+   * Heuristic: does this expression denote an arithmetic term (rather than a boolean formula)? Used
+   * only to classify {@code let} bindings in the arithmetic logics. A bare numeral/decimal, an
+   * arithmetic operator application ({@code + - * /}), or a symbol already bound to a term, are
+   * terms; everything else (predicate applications, boolean connectives, {@code true}/{@code false})
+   * is a formula.
+   */
+  private boolean looksLikeArithmeticTerm(SExpr e) {
+    if (e.isAtom()) {
+      Tok t = e.atom;
+      if (t.type() == SmtLibLexer.NUMERAL || t.type() == SmtLibLexer.DECIMAL) {
+        return true;
+      }
+      String v = t.value();
+      if (v.equals("true") || v.equals("false")) {
+        return false;
+      }
+      Object bound = lookupLet(v);
+      if (bound instanceof LinearTerm) {
+        return true;
+      }
+      if (bound instanceof PropositionalLogicExpression) {
+        return false;
+      }
+      // an unbound symbol where a let value is being classified: a declared numeric variable.
+      return true;
+    }
+    String head = e.head();
+    if (head == null) {
+      return false;
+    }
+    return switch (head) {
+      case "+", "-", "*", "/" -> true;
+      default -> false;
+    };
   }
 
   /** Creates the POSITIVE equality constraint for the current equality logic. */
@@ -491,133 +692,7 @@ public class SmtLibParser {
     return PropositionalLogicOr.or(top, new PropositionalLogicNegation(top));
   }
 
-  /** Adds the clauses produced by one asserted formula (CNF fragment). */
-  private void addFormula(SExpr formula) {
-    rejectNonCnf(formula);
-
-    String head = formula.isList() ? formula.head() : null;
-    if ("and".equals(head)) {
-      // conjunction of sub-formulas, each must itself be a clause (atom or or-of-atoms)
-      for (int i = 1; i < formula.list.size(); i++) {
-        addClause(formula.list.get(i));
-      }
-    } else {
-      addClause(formula);
-    }
-  }
-
-  /**
-   * Adds a clause from a formula: either an atom (unit clause) or an (or atom...) disjunction.
-   *
-   * <p>An atom may expand to several constraints (e.g. {@code (distinct a b c)} expands pairwise).
-   * As a top-level conjunct, those constraints are conjoined (each becomes its own unit clause).
-   * Inside an {@code or}, an atom must yield a single constraint, otherwise the pairwise expansion
-   * would be mis-interpreted as a disjunction; we reject that case.
-   */
-  private void addClause(SExpr formula) {
-    rejectNonCnf(formula);
-    String head = formula.isList() ? formula.head() : null;
-    if ("or".equals(head)) {
-      if (formula.list.size() < 2) {
-        throw err("'or' requires at least one disjunct", formula.index);
-      }
-      List<Constraint> constraints = new ArrayList<>();
-      for (int i = 1; i < formula.list.size(); i++) {
-        SExpr disjunct = formula.list.get(i);
-        List<Constraint> atomConstraints = parseAtom(disjunct);
-        if (atomConstraints.size() != 1) {
-          throw err(
-              "unsupported boolean structure (needs negation handling, issue #9): "
-                  + "pairwise 'distinct' with more than two arguments inside an 'or'",
-              disjunct.index);
-        }
-        constraints.addAll(atomConstraints);
-      }
-      clauses.add(new TheoryClause<>(constraints));
-    } else {
-      // unit atom; pairwise expansion -> conjunction -> one unit clause each
-      for (Constraint constraint : parseAtom(formula)) {
-        clauses.add(new TheoryClause<>(List.of(constraint)));
-      }
-    }
-  }
-
-  private void rejectNonCnf(SExpr formula) {
-    if (!formula.isList()) {
-      return;
-    }
-    String head = formula.head();
-    if (head == null) {
-      return;
-    }
-    switch (head) {
-      case "not", "=>", "implies", "ite", "xor", "iff" ->
-          throw err(
-              "unsupported boolean structure (needs negation handling, issue #9): '" + head + "'",
-              formula.index);
-      default -> {
-        /* ok */
-      }
-    }
-  }
-
-  // ---- atom parsing (returns 1 constraint, except distinct which expands pairwise) ----
-
-  private List<Constraint> parseAtom(SExpr atom) {
-    rejectNonCnf(atom);
-    if (!atom.isList()) {
-      throw err(
-          "expected an atom (a predicate application), found symbol '" + atom.atom.value() + "'",
-          atom.index);
-    }
-    String head = atom.head();
-    if (head == null) {
-      throw err("expected an atom", atom.index);
-    }
-
-    // Nested and/or inside a clause is not part of the CNF fragment.
-    if (head.equals("and") || head.equals("or")) {
-      throw err(
-          "unsupported boolean structure (needs negation handling, issue #9): nested '"
-              + head
-              + "' inside a clause",
-          atom.index);
-    }
-
-    return switch (kind) {
-      case ARITHMETIC -> List.of(parseArithmeticAtom(atom, head));
-      case EQUALITY -> parseEqualityAtom(atom, head);
-      case UF -> parseUfAtom(atom, head);
-    };
-  }
-
-  // ---- arithmetic (QF_LRA / QF_LIA) ----------------------------------------
-
-  private Constraint parseArithmeticAtom(SExpr atom, String head) {
-    switch (head) {
-      case "<", ">" ->
-          throw err(
-              "unsupported: strict inequality (no strict bound in LinearConstraint): '"
-                  + head
-                  + "'",
-              atom.index);
-      case "=", "<=", ">=" -> {
-        if (atom.list.size() != 3) {
-          throw err(
-              "'" + head + "' expects exactly two arguments in this subset", atom.index);
-        }
-        LinearTerm lhs = parseLinearTerm(atom.list.get(1));
-        LinearTerm rhs = parseLinearTerm(atom.list.get(2));
-        return switch (head) {
-          case "=" -> LinearConstraint.equal(lhs, rhs);
-          case "<=" -> LinearConstraint.lessThanOrEqual(lhs, rhs);
-          default -> LinearConstraint.greaterThanOrEqual(lhs, rhs);
-        };
-      }
-      default ->
-          throw err("unsupported arithmetic predicate '" + head + "'", atom.index);
-    }
-  }
+  // ---- arithmetic linear terms (QF_LRA / QF_LIA) ---------------------------
 
   private LinearTerm parseLinearTerm(SExpr e) {
     if (e.isAtom()) {
@@ -626,6 +701,15 @@ public class SmtLibParser {
         LinearTerm term = new LinearTerm();
         term.setConstant(Number.parse(t.value()));
         return term;
+      }
+      // a let-bound term symbol resolves to its expansion (a defensive copy).
+      Object bound = lookupLet(t.value());
+      if (bound instanceof LinearTerm boundTerm) {
+        return new LinearTerm(boundTerm);
+      }
+      if (bound instanceof PropositionalLogicExpression) {
+        throw err(
+            "let-bound symbol '" + t.value() + "' is a formula but is used as a term", e.index);
       }
       // a variable
       LinearTerm term = new LinearTerm();
@@ -696,10 +780,12 @@ public class SmtLibParser {
       term.setConstant(coefficient);
       return term;
     }
-    // multiply nonConstant by the scalar coefficient
+    // multiply nonConstant by the scalar coefficient. Use setCoefficient (result is fresh, each
+    // variable appears once): setCoefficient drops zero coefficients cleanly, whereas addCoefficient
+    // re-reads the just-removed entry and would NPE for a zero scalar such as (* 0 x).
     LinearTerm result = new LinearTerm();
     final Number coeff = coefficient;
-    nonConstant.getCoefficients().forEach((v, k) -> result.addCoefficient(v, k.multiply(coeff)));
+    nonConstant.getCoefficients().forEach((v, k) -> result.setCoefficient(v, k.multiply(coeff)));
     result.setConstant(nonConstant.getConstant().multiply(coeff));
     return result;
   }
@@ -769,82 +855,13 @@ public class SmtLibParser {
     }
   }
 
-  // ---- equality (QF_EQ) -----------------------------------------------------
-
-  private List<Constraint> parseEqualityAtom(SExpr atom, String head) {
-    switch (head) {
-      case "=" -> {
-        if (atom.list.size() != 3) {
-          throw err("'=' expects exactly two arguments in this subset", atom.index);
-        }
-        String left = requireVariable(atom.list.get(1));
-        String right = requireVariable(atom.list.get(2));
-        return List.of(new EqualityConstraint(left, right, true));
-      }
-      case "distinct" -> {
-        List<String> vars = new ArrayList<>();
-        for (int i = 1; i < atom.list.size(); i++) {
-          vars.add(requireVariable(atom.list.get(i)));
-        }
-        if (vars.size() < 2) {
-          throw err("'distinct' requires at least two arguments", atom.index);
-        }
-        // pairwise distinct expanded into separate constraints (conjunction). When this atom is a
-        // unit clause, multiple constraints in one clause would be a disjunction, which is wrong.
-        // We therefore only allow multi-arg distinct as a top-level/unit atom (handled by caller
-        // putting each in its own clause). For safety expand pairwise here; the caller for clauses
-        // with 'or' would mis-handle >2 args, so reject >2 inside a disjunction.
-        List<Constraint> result = new ArrayList<>();
-        for (int i = 0; i < vars.size(); i++) {
-          for (int j = i + 1; j < vars.size(); j++) {
-            result.add(new EqualityConstraint(vars.get(i), vars.get(j), false));
-          }
-        }
-        return result;
-      }
-      default ->
-          throw err("unsupported equality predicate '" + head + "'", atom.index);
-    }
-  }
+  // ---- equality / uninterpreted-function term helpers ----------------------
 
   private String requireVariable(SExpr e) {
     if (!e.isAtom()) {
       throw err("expected a variable/constant symbol", e.index);
     }
     return e.atom.value();
-  }
-
-  // ---- uninterpreted functions (QF_UF / QF_EQUF) ---------------------------
-
-  private List<Constraint> parseUfAtom(SExpr atom, String head) {
-    switch (head) {
-      case "=" -> {
-        if (atom.list.size() != 3) {
-          throw err("'=' expects exactly two arguments in this subset", atom.index);
-        }
-        Function left = parseFunctionTerm(atom.list.get(1));
-        Function right = parseFunctionTerm(atom.list.get(2));
-        return List.of(new EqualityFunctionConstraint(left, right, true));
-      }
-      case "distinct" -> {
-        List<Function> terms = new ArrayList<>();
-        for (int i = 1; i < atom.list.size(); i++) {
-          terms.add(parseFunctionTerm(atom.list.get(i)));
-        }
-        if (terms.size() < 2) {
-          throw err("'distinct' requires at least two arguments", atom.index);
-        }
-        List<Constraint> result = new ArrayList<>();
-        for (int i = 0; i < terms.size(); i++) {
-          for (int j = i + 1; j < terms.size(); j++) {
-            result.add(new EqualityFunctionConstraint(terms.get(i), terms.get(j), false));
-          }
-        }
-        return result;
-      }
-      default ->
-          throw err("unsupported equality predicate '" + head + "'", atom.index);
-    }
   }
 
   private Function parseFunctionTerm(SExpr e) {

--- a/src/main/java/me/paultristanwagner/satchecking/theory/LinearConstraint.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/LinearConstraint.java
@@ -4,6 +4,7 @@ import me.paultristanwagner.satchecking.smt.VariableAssignment;
 import me.paultristanwagner.satchecking.theory.arithmetic.Number;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import static me.paultristanwagner.satchecking.theory.LinearConstraint.Bound.*;
@@ -50,6 +51,14 @@ public class LinearConstraint implements Constraint {
 
   public static LinearConstraint greaterThanOrEqual(LinearTerm lhs, LinearTerm rhs) {
     return new LinearConstraint(lhs, rhs, GREATER_EQUALS);
+  }
+
+  public static LinearConstraint lessThan(LinearTerm lhs, LinearTerm rhs) {
+    return new LinearConstraint(lhs, rhs, LESS);
+  }
+
+  public static LinearConstraint greaterThan(LinearTerm lhs, LinearTerm rhs) {
+    return new LinearConstraint(lhs, rhs, GREATER);
   }
 
   public Set<String> getVariables() {
@@ -124,7 +133,26 @@ public class LinearConstraint implements Constraint {
   public enum Bound {
     GREATER_EQUALS,
     LESS_EQUALS,
-    EQUAL
+    EQUAL,
+    LESS,
+    GREATER
+  }
+
+  public boolean isNegatable() {
+    return bound != EQUAL;
+  }
+
+  public LinearConstraint negate() {
+    Bound newBound =
+        switch (bound) {
+          case LESS_EQUALS -> GREATER;
+          case GREATER_EQUALS -> LESS;
+          case LESS -> GREATER_EQUALS;
+          case GREATER -> LESS_EQUALS;
+          case EQUAL -> throw new UnsupportedOperationException("Cannot negate an equality constraint");
+        };
+
+    return new LinearConstraint(lhs, rhs, newBound);
   }
 
   @Override
@@ -137,8 +165,12 @@ public class LinearConstraint implements Constraint {
       sb.append("=");
     } else if (bound == GREATER_EQUALS) {
       sb.append(">=");
-    } else {
+    } else if (bound == LESS_EQUALS) {
       sb.append("<=");
+    } else if (bound == LESS) {
+      sb.append("<");
+    } else {
+      sb.append(">");
     }
 
     sb.append(rhs);
@@ -178,6 +210,19 @@ public class LinearConstraint implements Constraint {
     }
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LinearConstraint that = (LinearConstraint) o;
+    return bound == that.bound && lhs.equals(that.lhs) && rhs.equals(that.rhs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), lhs, rhs, bound);
+  }
+
   public boolean evaluate(VariableAssignment<Number> assignment) {
     Number lhsValue = lhs.evaluate(assignment);
     Number rhsValue = rhs.evaluate(assignment);
@@ -186,8 +231,12 @@ public class LinearConstraint implements Constraint {
       return lhsValue.equals(rhsValue);
     } else if (bound == GREATER_EQUALS) {
       return lhsValue.greaterThanOrEqual(rhsValue);
-    } else {
+    } else if (bound == LESS_EQUALS) {
       return lhsValue.lessThanOrEqual(rhsValue);
+    } else if (bound == LESS) {
+      return lhsValue.lessThan(rhsValue);
+    } else {
+      return lhsValue.greaterThan(rhsValue);
     }
   }
 }

--- a/src/main/java/me/paultristanwagner/satchecking/theory/LinearTerm.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/LinearTerm.java
@@ -6,6 +6,7 @@ import me.paultristanwagner.satchecking.theory.arithmetic.Number;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import static me.paultristanwagner.satchecking.theory.arithmetic.Number.ZERO;
@@ -132,6 +133,18 @@ public class LinearTerm {
     }
     result = result.add(constant);
     return result;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof LinearTerm that)) return false;
+    return coefficients.equals(that.coefficients) && constant.equals(that.constant);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(coefficients, constant);
   }
 
   @Override

--- a/src/main/java/me/paultristanwagner/satchecking/theory/Theory.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/Theory.java
@@ -66,7 +66,7 @@ public class Theory {
   public TheorySolver getTheorySolver() {
     return switch (name) {
       case QF_NRA_NAME -> new NonLinearRealArithmeticSolver();
-      case QF_LRA_NAME -> new SimplexOptimizationSolver();
+      case QF_LRA_NAME -> new LinearArithmeticSolver();
       case QF_LIA_NAME -> new LinearIntegerSolver();
       case QF_EQ_NAME -> new EqualityLogicSolver();
       case QF_EQUF_NAME -> new EqualityFunctionSolver();

--- a/src/main/java/me/paultristanwagner/satchecking/theory/arithmetic/DeltaRational.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/arithmetic/DeltaRational.java
@@ -1,0 +1,110 @@
+package me.paultristanwagner.satchecking.theory.arithmetic;
+
+import java.util.Objects;
+
+/**
+ * Represents a value of the form {@code c + k*delta} where {@code delta} is a positive
+ * infinitesimal (Dutertre / de Moura). The {@code rational} field is the concrete part {@code c}
+ * and the {@code delta} field is the coefficient {@code k} of the infinitesimal.
+ *
+ * <p>Comparison is lexicographic: first compare the rational parts, breaking ties on the delta
+ * coefficient. This realizes the ordering over the totally ordered field of "delta-rationals" and
+ * matches the standard encoding used to handle strict inequalities in a Simplex-based LRA solver.
+ *
+ * <p>Instances are immutable.
+ */
+public final class DeltaRational {
+
+  private final Number rational;
+  private final Number delta;
+
+  public static final DeltaRational ZERO = new DeltaRational(Number.ZERO(), Number.ZERO());
+
+  private DeltaRational(Number rational, Number delta) {
+    this.rational = rational;
+    this.delta = delta;
+  }
+
+  public static DeltaRational of(Number rational) {
+    return new DeltaRational(rational, Number.ZERO());
+  }
+
+  public static DeltaRational of(Number rational, Number delta) {
+    return new DeltaRational(rational, delta);
+  }
+
+  public Number getRational() {
+    return rational;
+  }
+
+  public Number getDelta() {
+    return delta;
+  }
+
+  public DeltaRational add(DeltaRational other) {
+    return new DeltaRational(rational.add(other.rational), delta.add(other.delta));
+  }
+
+  public DeltaRational subtract(DeltaRational other) {
+    return new DeltaRational(rational.subtract(other.rational), delta.subtract(other.delta));
+  }
+
+  /** Multiplies both the rational and the delta part by {@code factor}. */
+  public DeltaRational scale(Number factor) {
+    return new DeltaRational(rational.multiply(factor), delta.multiply(factor));
+  }
+
+  public DeltaRational negate() {
+    return new DeltaRational(rational.negate(), delta.negate());
+  }
+
+  public boolean lessThan(DeltaRational other) {
+    if (rational.lessThan(other.rational)) {
+      return true;
+    }
+    if (rational.greaterThan(other.rational)) {
+      return false;
+    }
+    return delta.lessThan(other.delta);
+  }
+
+  public boolean greaterThan(DeltaRational other) {
+    return other.lessThan(this);
+  }
+
+  public boolean lessThanOrEqual(DeltaRational other) {
+    return !other.lessThan(this);
+  }
+
+  public boolean greaterThanOrEqual(DeltaRational other) {
+    return !this.lessThan(other);
+  }
+
+  public boolean equalsValue(DeltaRational other) {
+    return rational.equals(other.rational) && delta.equals(other.delta);
+  }
+
+  public boolean isZero() {
+    return rational.isZero() && delta.isZero();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof DeltaRational that)) return false;
+    return rational.equals(that.rational) && delta.equals(that.delta);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(rational, delta);
+  }
+
+  @Override
+  public String toString() {
+    if (delta.isZero()) {
+      return rational.toString();
+    }
+    return "(" + rational + " + " + delta + "*delta)";
+  }
+}

--- a/src/main/java/me/paultristanwagner/satchecking/theory/solver/LinearArithmeticSolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/solver/LinearArithmeticSolver.java
@@ -1,0 +1,80 @@
+package me.paultristanwagner.satchecking.theory.solver;
+
+import me.paultristanwagner.satchecking.theory.LinearConstraint;
+import me.paultristanwagner.satchecking.theory.SimplexResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Dispatcher for QF_LRA. Accumulates linear constraints and routes them to the appropriate Simplex
+ * backend on {@link #solve()}:
+ *
+ * <ul>
+ *   <li>If any constraint is an optimization objective ({@link
+ *       LinearConstraint.MaximizingConstraint} / {@link LinearConstraint.MinimizingConstraint}),
+ *       delegate to a fresh {@link SimplexOptimizationSolver}.
+ *   <li>Otherwise (objective-free feasibility) delegate to a fresh {@link
+ *       SimplexFeasibilitySolver}, which supports strict inequalities via the delta-rational
+ *       method.
+ * </ul>
+ */
+public class LinearArithmeticSolver implements TheorySolver<LinearConstraint> {
+
+  private final List<LinearConstraint> constraints = new ArrayList<>();
+
+  @Override
+  public void clear() {
+    constraints.clear();
+  }
+
+  @Override
+  public void addConstraint(LinearConstraint constraint) {
+    constraints.add(constraint);
+  }
+
+  @Override
+  public SimplexResult solve() {
+    boolean optimization = false;
+    for (LinearConstraint constraint : constraints) {
+      if (constraint instanceof LinearConstraint.MaximizingConstraint
+          || constraint instanceof LinearConstraint.MinimizingConstraint) {
+        optimization = true;
+        break;
+      }
+    }
+
+    if (!optimization) {
+      // Objective-free feasibility: the feasibility solver supports strict inequalities exactly
+      // via the delta-rational method.
+      SimplexFeasibilitySolver delegate = new SimplexFeasibilitySolver();
+      for (LinearConstraint constraint : constraints) {
+        delegate.addConstraint(constraint);
+      }
+      return (SimplexResult) delegate.solve();
+    }
+
+    // Optimization: the SimplexOptimizationSolver does NOT support strict bounds. Strict
+    // inequalities only enter this path through Boolean-negated atoms during SMT enumeration.
+    // We relax each strict bound to its non-strict closure (LESS -> LESS_EQUALS, GREATER ->
+    // GREATER_EQUALS) so the optimum is computed over the closure of the feasible region. This
+    // matches the documented scope: strict support lives in the feasibility solver only.
+    SimplexOptimizationSolver delegate = new SimplexOptimizationSolver();
+    for (LinearConstraint constraint : constraints) {
+      delegate.addConstraint(relaxStrict(constraint));
+    }
+    return (SimplexResult) delegate.solve();
+  }
+
+  private static LinearConstraint relaxStrict(LinearConstraint constraint) {
+    return switch (constraint.getBound()) {
+      case LESS ->
+          LinearConstraint.lessThanOrEqual(
+              constraint.getLeftHandSide(), constraint.getRightHandSide());
+      case GREATER ->
+          LinearConstraint.greaterThanOrEqual(
+              constraint.getLeftHandSide(), constraint.getRightHandSide());
+      default -> constraint;
+    };
+  }
+}

--- a/src/main/java/me/paultristanwagner/satchecking/theory/solver/LinearIntegerSolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/solver/LinearIntegerSolver.java
@@ -47,9 +47,28 @@ public class LinearIntegerSolver implements TheorySolver<LinearConstraint> {
 
     boolean unknownInvolved = false;
 
-    SimplexOptimizationSolver simplexSolver = new SimplexOptimizationSolver();
-    simplexSolver.load(constraints);
-    TheoryResult<LinearConstraint> result = simplexSolver.solve();
+    // Determine whether the problem carries an objective function. Strict inequalities are only
+    // supported by the feasibility solver, so the objective-free feasibility check must use it.
+    boolean hasObjective = false;
+    for (LinearConstraint constraint : constraints) {
+      if (constraint instanceof LinearConstraint.MaximizingConstraint
+          || constraint instanceof LinearConstraint.MinimizingConstraint) {
+        hasObjective = true;
+        break;
+      }
+    }
+
+    SimplexOptimizationSolver simplexSolver = null;
+    TheoryResult<LinearConstraint> result;
+    if (hasObjective) {
+      simplexSolver = new SimplexOptimizationSolver();
+      simplexSolver.load(constraints);
+      result = simplexSolver.solve();
+    } else {
+      SimplexFeasibilitySolver feasibilitySolver = new SimplexFeasibilitySolver();
+      feasibilitySolver.load(constraints);
+      result = feasibilitySolver.solve();
+    }
 
     if (!result.isSatisfiable()) {
       return result;
@@ -84,9 +103,9 @@ public class LinearIntegerSolver implements TheorySolver<LinearConstraint> {
     solverA.load(constraints);
     solverA.addConstraint(upperBound);
 
-    boolean isOptimizationProblem = simplexSolver.hasObjectiveFunction();
-    boolean isMaximizationProblem = simplexSolver.isMaximization();
-    boolean isMinimizationProblem = simplexSolver.isMinimization();
+    boolean isOptimizationProblem = simplexSolver != null && simplexSolver.hasObjectiveFunction();
+    boolean isMaximizationProblem = simplexSolver != null && simplexSolver.isMaximization();
+    boolean isMinimizationProblem = simplexSolver != null && simplexSolver.isMinimization();
 
     Number localOptimum = null;
     LinearTerm objective = null;

--- a/src/main/java/me/paultristanwagner/satchecking/theory/solver/SimplexFeasibilitySolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/solver/SimplexFeasibilitySolver.java
@@ -3,6 +3,7 @@ package me.paultristanwagner.satchecking.theory.solver;
 import me.paultristanwagner.satchecking.smt.VariableAssignment;
 import me.paultristanwagner.satchecking.theory.LinearConstraint;
 import me.paultristanwagner.satchecking.theory.SimplexResult;
+import me.paultristanwagner.satchecking.theory.arithmetic.DeltaRational;
 import me.paultristanwagner.satchecking.theory.arithmetic.Number;
 
 import java.util.*;
@@ -19,16 +20,24 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
 
   private List<String> basicVariables;
   private List<String> nonBasicVariables;
-  private List<Number> values;
+  private List<DeltaRational> values;
 
-  private Map<String, Number> lowerBounds;
-  private Map<String, Number> upperBounds;
+  private Map<String, DeltaRational> lowerBounds;
+  private Map<String, DeltaRational> upperBounds;
 
   private final List<LinearConstraint> constraints = new ArrayList<>();
 
   @Override
   public void clear() {
-    throw new UnsupportedOperationException();
+    constraints.clear();
+    tableau = null;
+    basicVariables = null;
+    nonBasicVariables = null;
+    values = null;
+    lowerBounds = null;
+    upperBounds = null;
+    rows = 0;
+    columns = 0;
   }
 
   @Override
@@ -58,7 +67,7 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
     nonBasicVariables = new ArrayList<>(variables);
     values = new ArrayList<>();
     for (int i = 0; i < variables.size(); i++) {
-      values.add(ZERO());
+      values.add(DeltaRational.ZERO);
     }
 
     // Initialize slack variables, tableau and constraints
@@ -74,18 +83,25 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
         tableau[i][j] = constraint.getDifference().getCoefficients().getOrDefault(variable, ZERO());
       }
 
-      if (constraint.getBound() == EQUAL) {
-        lowerBounds.put(slackName, constraint.getDifference().getConstant().negate());
-        upperBounds.put(slackName, constraint.getDifference().getConstant().negate());
-      } else if (constraint.getBound() == LESS_EQUALS) {
-        upperBounds.put(slackName, constraint.getDifference().getConstant().negate());
-      } else if (constraint.getBound() == GREATER_EQUALS) {
-        lowerBounds.put(slackName, constraint.getDifference().getConstant().negate());
+      // c is the value the row-term (sum of coefficient*variable) is bounded against.
+      Number c = constraint.getDifference().getConstant().negate();
+
+      switch (constraint.getBound()) {
+        case EQUAL -> {
+          lowerBounds.put(slackName, DeltaRational.of(c));
+          upperBounds.put(slackName, DeltaRational.of(c));
+        }
+        case LESS_EQUALS -> upperBounds.put(slackName, DeltaRational.of(c));
+        case GREATER_EQUALS -> lowerBounds.put(slackName, DeltaRational.of(c));
+        // strict: s < c  <=>  s <= c - delta
+        case LESS -> upperBounds.put(slackName, DeltaRational.of(c, ONE().negate()));
+        // strict: s > c  <=>  s >= c + delta
+        case GREATER -> lowerBounds.put(slackName, DeltaRational.of(c, ONE()));
       }
     }
 
     this.rows = tableau.length;
-    this.columns = tableau[0].length;
+    this.columns = tableau.length == 0 ? 0 : tableau[0].length;
 
     while (true) {
       Violation violation = getViolation();
@@ -101,18 +117,98 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
       pivot(violation.variable(), pivotVariable, violation.increase());
     }
 
+    // The current assignment is feasible over the delta-rationals. Pick a concrete, safe
+    // positive delta to materialize a real-valued witness (see chooseDelta).
+    Number delta = chooseDelta();
+
     VariableAssignment variableAssignment = new VariableAssignment();
 
     for (String variable : variables) {
-      Number value;
+      DeltaRational value;
       if (basicVariables.contains(variable)) {
         value = getBasicValue(basicVariables.indexOf(variable));
       } else {
         value = values.get(nonBasicVariables.indexOf(variable));
       }
-      variableAssignment.assign(variable, value);
+      // materialize c + k*delta
+      Number concrete = value.getRational().add(value.getDelta().multiply(delta));
+      variableAssignment.assign(variable, concrete);
     }
     return SimplexResult.feasible(variableAssignment);
+  }
+
+  /**
+   * Chooses a concrete positive delta such that every delta-rational variable value {@code (c, k)}
+   * stays within its bounds. The verdict (SAT/UNSAT) does NOT depend on this choice; delta only
+   * shapes the concrete witness.
+   *
+   * <p>For each basic variable with value {@code (c_val, k_val)} we look at its bounds {@code
+   * (c_bound, k_bound)}. The materialized value {@code c_val + k_val*delta} must respect {@code
+   * c_bound + k_bound*delta}. When the rational parts are equal the constraint is already satisfied
+   * for any delta (the delta parts are consistent by construction of the feasible point). When the
+   * rational parts differ, the bound is strictly satisfied for all sufficiently small delta; the
+   * critical delta where it would be violated is {@code (c_bound - c_val) / (k_val - k_bound)},
+   * which we take only when positive. We pick delta to be the minimum of all such positive critical
+   * values (halved, to stay strictly inside), or 1 when there is no such bound.
+   */
+  private Number chooseDelta() {
+    Number delta = null; // will hold the minimum positive critical ratio
+
+    for (int i = 0; i < rows; i++) {
+      String variable = basicVariables.get(i);
+      DeltaRational value = getBasicValue(i);
+
+      DeltaRational upper = upperBounds.get(variable);
+      if (upper != null) {
+        Number ratio = criticalRatio(value, upper);
+        if (ratio != null && (delta == null || ratio.lessThan(delta))) {
+          delta = ratio;
+        }
+      }
+
+      DeltaRational lower = lowerBounds.get(variable);
+      if (lower != null) {
+        Number ratio = criticalRatio(value, lower);
+        if (ratio != null && (delta == null || ratio.lessThan(delta))) {
+          delta = ratio;
+        }
+      }
+    }
+
+    if (delta == null) {
+      return ONE();
+    }
+
+    // Stay strictly below the critical value to keep all strict bounds satisfied.
+    return delta.divide(Number.number(2));
+  }
+
+  /**
+   * Returns the positive critical delta where {@code value} would meet {@code bound}, or null if
+   * the bound imposes no positive upper limit on delta (rational parts equal, or the value moves
+   * away from the bound as delta grows).
+   *
+   * <p>value = (c_val, k_val), bound = (c_bound, k_bound). Critical delta = (c_bound - c_val) /
+   * (k_val - k_bound), taken only when both numerator-direction and denominator make it positive.
+   */
+  private Number criticalRatio(DeltaRational value, DeltaRational bound) {
+    Number cDiff = bound.getRational().subtract(value.getRational()); // c_bound - c_val
+    Number kDiff = value.getDelta().subtract(bound.getDelta()); // k_val - k_bound
+
+    if (cDiff.isZero()) {
+      // rational parts equal: feasibility already holds in the delta-part for all delta > 0.
+      return null;
+    }
+    if (kDiff.isZero()) {
+      // delta does not move value relative to bound; rational parts already separate them.
+      return null;
+    }
+
+    Number ratio = cDiff.divide(kDiff);
+    if (ratio.isPositive()) {
+      return ratio;
+    }
+    return null;
   }
 
   private Set<LinearConstraint> calculateExplanation(Violation violation) {
@@ -142,20 +238,20 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
     Violation result = null;
     for (int i = 0; i < rows; i++) {
       String variable = basicVariables.get(i);
-      Number value = getBasicValue(i);
+      DeltaRational value = getBasicValue(i);
       if (result != null && result.variable().compareTo(variable) < 0) {
         continue;
       }
 
       if (upperBounds.containsKey(variable)) {
-        Number u = upperBounds.get(variable);
+        DeltaRational u = upperBounds.get(variable);
         if (value.greaterThan(u)) {
           result = new Violation(variable, false);
         }
       }
 
       if (lowerBounds.containsKey(variable)) {
-        Number l = lowerBounds.get(variable);
+        DeltaRational l = lowerBounds.get(variable);
         if (value.lessThan(l)) {
           result = new Violation(variable, true);
         }
@@ -198,10 +294,10 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
     int nonBasicIndex = this.nonBasicVariables.indexOf(nonBasic);
 
     if (increase) {
-      Number l = lowerBounds.get(basic);
+      DeltaRational l = lowerBounds.get(basic);
       values.set(nonBasicIndex, l);
     } else {
-      Number u = upperBounds.get(basic);
+      DeltaRational u = upperBounds.get(basic);
       values.set(nonBasicIndex, u);
     }
 
@@ -236,8 +332,8 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
 
   private boolean canBeIncreased(String variable) {
     if (upperBounds.containsKey(variable)) {
-      Number u = upperBounds.get(variable);
-      Number value = values.get(nonBasicVariables.indexOf(variable));
+      DeltaRational u = upperBounds.get(variable);
+      DeltaRational value = values.get(nonBasicVariables.indexOf(variable));
 
       return value.lessThan(u);
     }
@@ -246,18 +342,18 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
 
   private boolean canBeDecreased(String variable) {
     if (lowerBounds.containsKey(variable)) {
-      Number l = lowerBounds.get(variable);
-      Number value = values.get(nonBasicVariables.indexOf(variable));
+      DeltaRational l = lowerBounds.get(variable);
+      DeltaRational value = values.get(nonBasicVariables.indexOf(variable));
 
       return value.greaterThan(l);
     }
     return true;
   }
 
-  public Number getBasicValue(int row) {
-    Number result = ZERO();
+  public DeltaRational getBasicValue(int row) {
+    DeltaRational result = DeltaRational.ZERO;
     for (int i = 0; i < columns; i++) {
-      Number summand = tableau[row][i].multiply(values.get(i));
+      DeltaRational summand = values.get(i).scale(tableau[row][i]);
       result = result.add(summand);
     }
     return result;
@@ -268,21 +364,21 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
     System.out.print("       ");
     for (int i = 0; i < nonBasicVariables.size(); i++) {
       String variable = nonBasicVariables.get(i);
-      System.out.printf(" %s[%.2f]", variable, values.get(i));
+      System.out.printf(" %s[%s]", variable, values.get(i));
     }
     System.out.println();
 
     for (int i = 0; i < rows; i++) {
-      System.out.printf("%s[%.2f] ", basicVariables.get(i), getBasicValue(i));
+      System.out.printf("%s[%s] ", basicVariables.get(i), getBasicValue(i));
       for (int j = 0; j < columns; j++) {
-        System.out.printf("  %.2f  ", tableau[i][j]);
+        System.out.printf("  %s  ", tableau[i][j]);
       }
       System.out.println();
     }
 
     System.out.println();
-    upperBounds.forEach((v, u) -> System.out.printf("%s <= %.2f%n", v, u));
-    lowerBounds.forEach((v, l) -> System.out.printf("%s >= %.2f%n", v, l));
+    upperBounds.forEach((v, u) -> System.out.printf("%s <= %s%n", v, u));
+    lowerBounds.forEach((v, l) -> System.out.printf("%s >= %s%n", v, l));
 
     System.out.println("---------------------");
   }

--- a/src/test/java/SmtLibArithmeticBooleanTest.java
+++ b/src/test/java/SmtLibArithmeticBooleanTest.java
@@ -1,0 +1,85 @@
+import me.paultristanwagner.satchecking.command.impl.SmtLibCommand;
+import me.paultristanwagner.satchecking.command.impl.SmtLibCommand.Verdict;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for full boolean structure (and/or/not/=>/ite/xor), {@code let} bindings, {@code =}-splitting
+ * and strict inequalities over arithmetic atoms in the arithmetic logics (QF_LRA, QF_LIA).
+ *
+ * @author Paul Tristan Wagner <paultristanwagner@gmail.com>
+ */
+public class SmtLibArithmeticBooleanTest {
+
+  private static Verdict run(String script) {
+    return SmtLibCommand.runScript(script, false);
+  }
+
+  @Test
+  public void testLraEqualitySplitContradictsStrictDisjunction() {
+    // (= x 0) splits into x<=0 and x>=0, contradicting x<0 or x>0.
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_LRA)(declare-const x Real)"
+                + "(assert (or (< x 0) (> x 0)))(assert (= x 0))(check-sat)"));
+  }
+
+  @Test
+  public void testLraNegatedNonStrictBecomesStrict() {
+    // (not (<= x 3)) is x>3; together with x<=5 this is satisfiable (3<x<=5).
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_LRA)(declare-const x Real)"
+                + "(assert (and (<= x 5) (not (<= x 3))))(check-sat)"));
+  }
+
+  @Test
+  public void testLraImplication() {
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_LRA)(declare-const x Real)"
+                + "(assert (=> (<= x 0) (<= x (- 1))))(assert (<= x 0))(check-sat)"));
+  }
+
+  @Test
+  public void testLraLetBindingOverTerm() {
+    // let binds s = x + y; assert s = 1 (split) and x < 0.
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_LRA)(declare-const x Real)(declare-const y Real)"
+                + "(assert (let ((s (+ x y))) (and (<= s 1) (>= s 1) (< x 0))))(check-sat)"));
+  }
+
+  @Test
+  public void testLiaStrictRangeUnsat() {
+    // No integer strictly between 0 and 1.
+    assertEquals(
+        Verdict.UNSAT,
+        run("(set-logic QF_LIA)(declare-const x Int)(assert (and (> x 0) (< x 1)))(check-sat)"));
+  }
+
+  @Test
+  public void testLiaDisjunctionWithNegatedEquality() {
+    // x=2 or x=3, and not x=2  =>  x=3.
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_LIA)(declare-const x Int)"
+                + "(assert (or (= x 2) (= x 3)))(assert (not (= x 2)))(check-sat)"));
+  }
+
+  @Test
+  public void testEqualityLogicRegression() {
+    // a = b implies f(a) = f(b); asserting f(a) != f(b) is unsat by congruence.
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_UF)(declare-sort U 0)(declare-const a U)(declare-const b U)"
+                + "(declare-fun f (U) U)(assert (= a b))(assert (not (= (f a) (f b))))(check-sat)"));
+  }
+}

--- a/src/test/java/SmtLibBooleanStructureTest.java
+++ b/src/test/java/SmtLibBooleanStructureTest.java
@@ -1,6 +1,5 @@
 import me.paultristanwagner.satchecking.command.impl.SmtLibCommand;
 import me.paultristanwagner.satchecking.command.impl.SmtLibCommand.Verdict;
-import me.paultristanwagner.satchecking.parse.SyntaxError;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -79,13 +78,14 @@ public class SmtLibBooleanStructureTest {
   }
 
   @Test
-  public void testArithmeticStillRejectsStrictAndNegation() {
-    assertThrows(
-        SyntaxError.class,
-        () -> run("(set-logic QF_LRA)(declare-const x Real)(assert (< x 5))(check-sat)"));
-    assertThrows(
-        SyntaxError.class,
-        () ->
-            run("(set-logic QF_LRA)(declare-const x Real)(assert (not (<= x 5)))(check-sat)"));
+  public void testArithmeticNowAcceptsStrictAndNegation() {
+    // Strict inequalities and negation are now supported for the arithmetic logics (the strict
+    // foundation made the bounds real). See SmtLibArithmeticBooleanTest for behavioural coverage.
+    assertEquals(
+        Verdict.SAT,
+        run("(set-logic QF_LRA)(declare-const x Real)(assert (< x 5))(check-sat)"));
+    assertEquals(
+        Verdict.SAT,
+        run("(set-logic QF_LRA)(declare-const x Real)(assert (not (<= x 5)))(check-sat)"));
   }
 }

--- a/src/test/java/SmtLibParserTest.java
+++ b/src/test/java/SmtLibParserTest.java
@@ -125,37 +125,30 @@ public class SmtLibParserTest {
   }
 
   @Test
-  public void testStrictInequalityRejected() {
-    SyntaxError error =
-        assertThrows(
-            SyntaxError.class,
-            () ->
-                run("(set-logic QF_LRA)(declare-const x Real)(assert (< x 5))(check-sat)"));
-    assertTrue(error.getMessage().contains("strict inequality"), error.getMessage());
+  public void testStrictInequalityAccepted() {
+    // Strict inequalities are now supported for the arithmetic logics.
+    assertEquals(
+        Verdict.SAT,
+        run("(set-logic QF_LRA)(declare-const x Real)(assert (< x 5))(check-sat)"));
   }
 
   @Test
-  public void testNegationRejected() {
-    SyntaxError error =
-        assertThrows(
-            SyntaxError.class,
-            () ->
-                run(
-                    "(set-logic QF_EQ)(declare-const a U)(declare-const b U)"
-                        + "(assert (not (= a b)))(check-sat)"));
-    assertTrue(error.getMessage().contains("unsupported boolean structure"), error.getMessage());
+  public void testNegationAccepted() {
+    // Boolean negation over atoms is supported in all logics.
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_EQ)(declare-const a U)(declare-const b U)"
+                + "(assert (not (= a b)))(check-sat)"));
   }
 
   @Test
-  public void testImpliesRejected() {
-    SyntaxError error =
-        assertThrows(
-            SyntaxError.class,
-            () ->
-                run(
-                    "(set-logic QF_EQ)(declare-const a U)(declare-const b U)(declare-const c U)"
-                        + "(assert (=> (= a b) (= b c)))(check-sat)"));
-    assertTrue(error.getMessage().contains("unsupported boolean structure"), error.getMessage());
+  public void testImpliesAccepted() {
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_EQ)(declare-const a U)(declare-const b U)(declare-const c U)"
+                + "(assert (=> (= a b) (= b c)))(check-sat)"));
   }
 
   @Test

--- a/src/test/java/StrictInequalityTest.java
+++ b/src/test/java/StrictInequalityTest.java
@@ -1,0 +1,155 @@
+import me.paultristanwagner.satchecking.parse.LinearConstraintParser;
+import me.paultristanwagner.satchecking.parse.ParseResult;
+import me.paultristanwagner.satchecking.parse.TheoryCNFParser;
+import me.paultristanwagner.satchecking.sat.solver.DPLLCDCLSolver;
+import me.paultristanwagner.satchecking.smt.SMTResult;
+import me.paultristanwagner.satchecking.smt.TheoryCNF;
+import me.paultristanwagner.satchecking.smt.VariableAssignment;
+import me.paultristanwagner.satchecking.smt.solver.SMTSolver;
+import me.paultristanwagner.satchecking.theory.SimplexResult;
+import me.paultristanwagner.satchecking.theory.Theory;
+import me.paultristanwagner.satchecking.theory.arithmetic.Number;
+import me.paultristanwagner.satchecking.theory.solver.SimplexFeasibilitySolver;
+import me.paultristanwagner.satchecking.theory.solver.TheorySolver;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for strict inequality support ({@code <}, {@code >}) in linear real / integer arithmetic,
+ * implemented via the delta-rational method (Dutertre / de Moura).
+ */
+public class StrictInequalityTest {
+
+  private final LinearConstraintParser parser = new LinearConstraintParser();
+
+  @SuppressWarnings("unchecked")
+  private static SMTResult<?> solve(String theoryName, String formula) {
+    Theory theory = Theory.get(theoryName);
+    TheoryCNFParser parser = theory.getCNFParser();
+    SMTSolver solver = theory.getSMTSolver();
+    solver.setSATSolver(new DPLLCDCLSolver());
+    solver.setTheorySolver((TheorySolver) theory.getTheorySolver());
+
+    ParseResult<TheoryCNF<?>> pr = parser.parseWithRemaining(formula);
+    solver.load((TheoryCNF) pr.result());
+    return solver.solve();
+  }
+
+  private static Number valueOf(SMTResult<?> result, String variable) {
+    VariableAssignment<Number> solution = (VariableAssignment<Number>) result.getSolution();
+    return solution.getAssignment(variable);
+  }
+
+  private static void assertNumberEquals(long expected, Number actual) {
+    Number e = Number.number(expected);
+    assertTrue(
+        actual.greaterThanOrEqual(e) && actual.lessThanOrEqual(e),
+        "expected " + expected + " but was " + actual);
+  }
+
+  // --- Direct SimplexFeasibilitySolver strict case --------------------------------------------
+
+  @Test
+  public void directStrictInfeasible() {
+    SimplexFeasibilitySolver simplex = new SimplexFeasibilitySolver();
+    simplex.addConstraint(parser.parse("x<5"));
+    simplex.addConstraint(parser.parse("x>5"));
+
+    SimplexResult result = simplex.solve();
+    assertFalse(result.isFeasible());
+  }
+
+  @Test
+  public void directStrictFeasibleWitnessSatisfiesStrictBounds() {
+    SimplexFeasibilitySolver simplex = new SimplexFeasibilitySolver();
+    simplex.addConstraint(parser.parse("x<5"));
+    simplex.addConstraint(parser.parse("x>3"));
+
+    SimplexResult result = simplex.solve();
+    assertTrue(result.isFeasible());
+
+    VariableAssignment<Number> solution = (VariableAssignment<Number>) result.getSolution();
+    Number x = solution.getAssignment("x");
+    assertTrue(x.greaterThan(Number.number(3)), "x must be strictly > 3, was " + x);
+    assertTrue(x.lessThan(Number.number(5)), "x must be strictly < 5, was " + x);
+  }
+
+  @Test
+  public void clearMakesSolverReusable() {
+    SimplexFeasibilitySolver simplex = new SimplexFeasibilitySolver();
+    simplex.addConstraint(parser.parse("x>5"));
+    simplex.addConstraint(parser.parse("x<5"));
+    assertFalse(simplex.solve().isFeasible());
+
+    simplex.clear();
+    simplex.addConstraint(parser.parse("x>3"));
+    simplex.addConstraint(parser.parse("x<5"));
+    assertTrue(simplex.solve().isFeasible());
+  }
+
+  // --- QF_LRA strict via the SMT pipeline -----------------------------------------------------
+
+  @Test
+  public void strictConflictUnsat() {
+    assertFalse(solve("QF_LRA", "(x<5)&(x>5)").isSatisfiable());
+  }
+
+  @Test
+  public void strictRangeSat() {
+    assertTrue(solve("QF_LRA", "(x<5)&(x>3)").isSatisfiable());
+  }
+
+  @Test
+  public void strictAgainstClosedBoundaryUnsat() {
+    assertFalse(solve("QF_LRA", "(x<5)&(x>=5)").isSatisfiable());
+  }
+
+  @Test
+  public void closedBoundaryEqualSat() {
+    assertTrue(solve("QF_LRA", "(x<=5)&(x>=5)").isSatisfiable());
+  }
+
+  @Test
+  public void scaledStrictRangeSat() {
+    assertTrue(solve("QF_LRA", "(2x<3)&(2x>2)").isSatisfiable());
+  }
+
+  // --- QF_LRA optimization still works (strict relaxed to closure in objective path) ----------
+
+  @Test
+  public void minimizationWithDisjunctionAndCoupling() {
+    SMTResult<?> result = solve("QF_LRA", "(x<=-3|x>=3)&(y=5)&(x+y>=12)&(min(x))");
+    assertTrue(result.isSatisfiable());
+    assertNumberEquals(7, valueOf(result, "x"));
+  }
+
+  @Test
+  public void maximizationOverDisjunction() {
+    SMTResult<?> result = solve("QF_LRA", "(x<=5|x<=100)&(max(x))");
+    assertTrue(result.isSatisfiable());
+    assertNumberEquals(100, valueOf(result, "x"));
+  }
+
+  // --- QF_LIA strict --------------------------------------------------------------------------
+
+  @Test
+  public void integerStrictRangeUnsat() {
+    assertFalse(solve("QF_LIA", "(x<1)&(x>0)").isSatisfiable());
+  }
+
+  @Test
+  public void integerStrictRangeSat() {
+    SMTResult<?> result = solve("QF_LIA", "(x>0)&(x<5)&(2x=4)");
+    assertTrue(result.isSatisfiable());
+    assertNumberEquals(2, valueOf(result, "x"));
+  }
+
+  @Test
+  public void integerClosedPointSat() {
+    SMTResult<?> result = solve("QF_LIA", "(x>=3)&(x<=3)");
+    assertTrue(result.isSatisfiable());
+    assertNumberEquals(3, valueOf(result, "x"));
+  }
+}


### PR DESCRIPTION
## QF_LRA / QF_LIA: strict inequalities + arithmetic boolean structure + `let` (feasibility)

Brings real SMT-LIB QF_LRA/QF_LIA **feasibility** benchmarks from *unsupported* to *solving soundly*. Two stages on one branch.

### Stage A — strict inequalities in the theory core (δ-rational)
- `LinearConstraint.Bound` gains `LESS`/`GREATER`; factories, `evaluate`, `toString`; `negate()`/`isNegatable()` (≤↔>, ≥↔<; `EQUAL` not negatable).
- New `DeltaRational` (`c + k·δ`) with lexicographic comparison — the Dutertre–de Moura infinitesimal.
- `SimplexFeasibilitySolver` reworked to δ-rational bounds/values (strict `<` → upper `c−δ`, `>` → lower `c+δ`), with a working `clear()` and a concrete-δ witness extractor. **The SAT/UNSAT verdict never depends on δ** (δ-rational feasibility ⟺ real feasibility); δ only shapes the witness.
- New `LinearArithmeticSolver` dispatcher routes objective-free QF_LRA through the (now strict-capable) feasibility solver; objective problems still use the optimization solver. `LinearIntegerSolver` uses the feasibility solver for its relaxation. `LinearConstraintParser` accepts `<`/`>`.
- **Out of scope:** strict bounds inside the *optimization* solver / strict objectives (relaxed to closure on the objective path — affects only objective+strict optima, not feasibility verdicts).

### Stage B — SMT-LIB arithmetic boolean structure + `let`
- QF_LRA/QF_LIA `assert` now accepts arbitrary `and`/`or`/`not`/`=>`/`ite`/`xor` over atoms, via the same Tseitin → `TheoryCNF(CNF,BiMap)` path the equality logics use.
- `(= s t)` is **split into `(and (<= s t) (>= s t))`**, so `distinct`/`not (=)` become strict disjunctions and every atom's negation is a single (strict) constraint — no theory-level disequality needed.
- `let` bindings (terms and formulas; scoped, nested, shadowing). Strict atoms accepted. Nonlinear still rejected.

### Verification (no Maven in dev env → standalone harnesses + a JUnit launcher)
- Full regression green: differential SAT 0/0/0; #10/#14/#20/#36 intact; existing Simplex/optimization test assertions hold.
- Strict hand cases (QF_LRA + QF_LIA feasibility, and objective+strict **verdicts**) all correct.
- **Real SMT-LIB 2025 benchmarks** (smallest-N per logic, 8s timeout):
  - qflra: **60/60** correct (57 SAT, 3 UNSAT); qflia: **60/60** (42 SAT, 18 UNSAT).
  - UNSAT-only gate (spurious-SAT check): qflra **30/30**, qflia **29/29** correct UNSAT.
  - **~179 real benchmarks, 0 mismatches, 0 crashes.**
- New `SmtLibArithmeticBooleanTest` + `StrictInequalityTest`; 3 obsolete "rejection" assertions updated to expect the now-supported verdicts.

### Still unsupported (honest scope)
Strict in the optimization solver / strict objectives; nonlinear; `define-fun`/`define-sort`; `push`/`pop` (warned+ignored); QF_BV/QF_NRA front-ends. Closes the arithmetic part of #9; advances #33.
