### PR TITLE
SMT-LIB QF_NRA front-end (nonlinear real arithmetic via CAD)

### DIFF
--- a/src/main/java/me/paultristanwagner/satchecking/command/impl/SmtLibCommand.java
+++ b/src/main/java/me/paultristanwagner/satchecking/command/impl/SmtLibCommand.java
@@ -187,6 +187,7 @@ public class SmtLibCommand extends Command {
       throw new SyntaxError("no logic set (expected a (set-logic ...) command)", "", 0);
     }
     return switch (logic) {
+      case "QF_NRA" -> "QF_NRA";
       case "QF_LRA" -> "QF_LRA";
       case "QF_LIA" -> "QF_LIA";
       case "QF_EQ" -> "QF_EQ";
@@ -195,7 +196,7 @@ public class SmtLibCommand extends Command {
           throw new SyntaxError(
               "unsupported logic '"
                   + logic
-                  + "' (supported: QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF)",
+                  + "' (supported: QF_NRA, QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF)",
               logic,
               0);
     };

--- a/src/main/java/me/paultristanwagner/satchecking/parse/SmtLibParser.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/SmtLibParser.java
@@ -19,6 +19,9 @@ import me.paultristanwagner.satchecking.theory.EqualityFunctionConstraint.Functi
 import me.paultristanwagner.satchecking.theory.LinearConstraint;
 import me.paultristanwagner.satchecking.theory.LinearTerm;
 import me.paultristanwagner.satchecking.theory.arithmetic.Number;
+import me.paultristanwagner.satchecking.theory.nonlinear.MultivariatePolynomial;
+import me.paultristanwagner.satchecking.theory.nonlinear.MultivariatePolynomialConstraint;
+import me.paultristanwagner.satchecking.theory.nonlinear.MultivariatePolynomialConstraint.Comparison;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -35,18 +38,27 @@ import java.util.Map;
  * the declared logic and the optional {@code :status}). It does not run the solver itself; see
  * {@code command/impl/SmtLibCommand}.
  *
- * <p>Supported logics: QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF. For ALL of these logics arbitrary
- * boolean structure over the theory atoms is supported (and/or/not/=>/xor/ite/true/false, including
- * negated atoms, {@code distinct} and {@code let} bindings); the conjunction of asserted formulas is
- * Tseitin-transformed and a {@link TheoryCNF} is returned via {@link SmtLibScript#getTheoryCNF()}.
+ * <p>Supported logics: QF_NRA, QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF. For ALL of these logics
+ * arbitrary boolean structure over the theory atoms is supported (and/or/not/=>/xor/ite/true/false,
+ * including negated atoms, {@code distinct} and {@code let} bindings); the conjunction of asserted
+ * formulas is Tseitin-transformed and a {@link TheoryCNF} is returned via {@link
+ * SmtLibScript#getTheoryCNF()}.
  *
  * <p>Equality logics (QF_EQ, QF_UF, QF_EQUF) build {@code EqualityConstraint}/{@code
- * EqualityFunctionConstraint} leaves. Arithmetic logics (QF_LRA, QF_LIA) build {@link
+ * EqualityFunctionConstraint} leaves. Linear arithmetic logics (QF_LRA, QF_LIA) build {@link
  * LinearConstraint} leaves over {@code <=}, {@code >=}, {@code <}, {@code >}; an {@code (= s t)}
  * atom is eliminated by splitting into {@code (and (<= s t) (>= s t))} so that every atom's negation
  * is a single (strict/non-strict) inequality, and {@code (distinct s t)} / {@code (not (= s t))}
- * become disjunctions of strict atoms. Only linear arithmetic terms are accepted; nonlinear products
- * are rejected.
+ * become disjunctions of strict atoms. Only linear arithmetic terms are accepted there; nonlinear
+ * products are rejected.
+ *
+ * <p>Nonlinear real arithmetic (QF_NRA) builds {@code MultivariatePolynomialConstraint} leaves over
+ * {@code <=}, {@code >=}, {@code <}, {@code >}, {@code =}, {@code distinct}, parsing {@code +},
+ * {@code -}, {@code *} (including nonlinear products), {@code ^} (integer powers) and rational-
+ * constant {@code /} into {@code MultivariatePolynomial}s. No {@code =}-splitting is done: EQUALS and
+ * NOT_EQUALS are native polynomial comparisons whose negation is exact, and the resulting constraints
+ * are solved by the (experimental) CAD-based {@code NonLinearRealArithmeticSolver}. Division by a
+ * non-constant polynomial is rejected as unsupported.
  *
  * @author Paul Tristan Wagner <paultristanwagner@gmail.com>
  */
@@ -162,6 +174,7 @@ public class SmtLibParser {
   // Logic kind. Determined by set-logic.
   private enum Kind {
     ARITHMETIC, // QF_LRA, QF_LIA
+    NONLINEAR, // QF_NRA
     EQUALITY, // QF_EQ
     UF // QF_UF, QF_EQUF
   }
@@ -409,13 +422,14 @@ public class SmtLibParser {
     logicName = args.get(0).atom.value();
     switch (logicName) {
       case "QF_LRA", "QF_LIA" -> kind = Kind.ARITHMETIC;
+      case "QF_NRA" -> kind = Kind.NONLINEAR;
       case "QF_EQ" -> kind = Kind.EQUALITY;
       case "QF_UF", "QF_EQUF" -> kind = Kind.UF;
       default ->
           throw err(
               "unsupported logic '"
                   + logicName
-                  + "' (supported: QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF)",
+                  + "' (supported: QF_NRA, QF_LRA, QF_LIA, QF_EQ, QF_UF, QF_EQUF)",
               index);
     }
   }
@@ -761,6 +775,9 @@ public class SmtLibParser {
     if (kind == Kind.ARITHMETIC) {
       return arithmeticAtomFormula(atom, head);
     }
+    if (kind == Kind.NONLINEAR) {
+      return nonlinearAtomFormula(atom, head);
+    }
     return equalityAtomFormula(atom, head);
   }
 
@@ -911,6 +928,170 @@ public class SmtLibParser {
     return PropositionalLogicAnd.and(le, ge);
   }
 
+  // ---- nonlinear arithmetic atoms (QF_NRA) ---------------------------------
+
+  /**
+   * Builds the propositional representation of a nonlinear-arithmetic atom over {@link
+   * MultivariatePolynomialConstraint} leaves. Every predicate {@code (op p q)} is normalized to a
+   * single constraint over the polynomial {@code p - q} compared against {@code 0}. Unlike the
+   * QF_LRA path there is NO {@code =}-splitting: EQUALS and NOT_EQUALS are native polynomial
+   * comparisons, and each atom's negation is the same polynomial with the flipped comparison (see
+   * {@link MultivariatePolynomialConstraint#negate()}), so the lazy SMT loop can negate atoms
+   * exactly. {@code (distinct ...)} over n operands becomes the conjunction over pairs of NOT_EQUALS
+   * atoms.
+   */
+  private PropositionalLogicExpression nonlinearAtomFormula(SExpr atom, String head) {
+    switch (head) {
+      case "<=", ">=", "<", ">", "=" -> {
+        if (atom.list.size() != 3) {
+          throw err("'" + head + "' expects exactly two arguments in this subset", atom.index);
+        }
+        MultivariatePolynomial lhs = parsePolynomial(atom.list.get(1));
+        MultivariatePolynomial rhs = parsePolynomial(atom.list.get(2));
+        MultivariatePolynomial difference = lhs.subtract(rhs);
+        Comparison comparison =
+            switch (head) {
+              case "<=" -> Comparison.LESS_THAN_OR_EQUALS;
+              case ">=" -> Comparison.GREATER_THAN_OR_EQUALS;
+              case "<" -> Comparison.LESS_THAN;
+              case ">" -> Comparison.GREATER_THAN;
+              default -> Comparison.EQUALS;
+            };
+        return atomVariable(
+            MultivariatePolynomialConstraint.multivariatePolynomialConstraint(difference, comparison));
+      }
+      case "distinct" -> {
+        List<SExpr> argExprs = atom.list.subList(1, atom.list.size());
+        if (argExprs.size() < 2) {
+          throw err("'distinct' requires at least two arguments", atom.index);
+        }
+        List<PropositionalLogicExpression> parts = new ArrayList<>();
+        for (int i = 0; i < argExprs.size(); i++) {
+          for (int j = i + 1; j < argExprs.size(); j++) {
+            MultivariatePolynomial a = parsePolynomial(argExprs.get(i));
+            MultivariatePolynomial b = parsePolynomial(argExprs.get(j));
+            parts.add(
+                atomVariable(
+                    MultivariatePolynomialConstraint.multivariatePolynomialConstraint(
+                        a.subtract(b), Comparison.NOT_EQUALS)));
+          }
+        }
+        return parts.size() == 1 ? parts.get(0) : PropositionalLogicAnd.and(parts);
+      }
+      default -> throw err("unsupported nonlinear arithmetic predicate '" + head + "'", atom.index);
+    }
+  }
+
+  /**
+   * Parses an arithmetic term in prefix form into a {@link MultivariatePolynomial}. Supports {@code
+   * (+ ...)}, {@code (- ...)} (unary negate and n-ary subtraction), {@code (* ...)} with NONLINEAR
+   * products (variable * variable), {@code (^ t n)} integer powers, numerals, decimals, declared
+   * variables, and {@code (/ p q)} where both operands are numeric constants (a rational
+   * coefficient). Division by a non-constant polynomial is rejected as unsupported. {@code let} and
+   * {@code define-fun} are resolved through the shared machinery.
+   */
+  private MultivariatePolynomial parsePolynomial(SExpr e) {
+    if (e.isAtom()) {
+      Tok t = e.atom;
+      if (t.type() == SmtLibLexer.NUMERAL || t.type() == SmtLibLexer.DECIMAL) {
+        return MultivariatePolynomial.constant(Number.parse(t.value()));
+      }
+      String v = t.value();
+      Object bound = lookupLet(v);
+      if (bound instanceof MultivariatePolynomial boundPoly) {
+        return boundPoly;
+      }
+      if (bound instanceof PropositionalLogicExpression) {
+        throw err("let-bound symbol '" + v + "' is a formula but is used as a term", e.index);
+      }
+      // a 0-ary define-fun used as a term expands to its (arithmetic) body.
+      SExpr expanded = expandDefineFun(e);
+      if (expanded != null) {
+        return parsePolynomial(expanded);
+      }
+      // a variable
+      return MultivariatePolynomial.variable(v);
+    }
+
+    String head = e.head();
+    if (head == null) {
+      throw err("malformed arithmetic term", e.index);
+    }
+    if (defineFuns.containsKey(head) && lookupLet(head) == null) {
+      SExpr expanded = expandDefineFun(e);
+      if (expanded != null) {
+        return parsePolynomial(expanded);
+      }
+    }
+    switch (head) {
+      case "let" -> {
+        Map<String, Object> frame = evaluateLetBindings(e);
+        letScopes.push(frame);
+        try {
+          return parsePolynomial(e.list.get(2));
+        } finally {
+          letScopes.pop();
+        }
+      }
+      case "+" -> {
+        MultivariatePolynomial term = MultivariatePolynomial.constant(Number.ZERO());
+        for (int i = 1; i < e.list.size(); i++) {
+          term = term.add(parsePolynomial(e.list.get(i)));
+        }
+        return term;
+      }
+      case "-" -> {
+        if (e.list.size() < 2) {
+          throw err("'-' requires at least one argument", e.index);
+        }
+        if (e.list.size() == 2) {
+          return parsePolynomial(e.list.get(1)).negate();
+        }
+        MultivariatePolynomial term = parsePolynomial(e.list.get(1));
+        for (int i = 2; i < e.list.size(); i++) {
+          term = term.subtract(parsePolynomial(e.list.get(i)));
+        }
+        return term;
+      }
+      case "*" -> {
+        if (e.list.size() < 3) {
+          throw err("'*' requires at least two arguments", e.index);
+        }
+        MultivariatePolynomial term = parsePolynomial(e.list.get(1));
+        for (int i = 2; i < e.list.size(); i++) {
+          term = term.multiply(parsePolynomial(e.list.get(i)));
+        }
+        return term;
+      }
+      case "^" -> {
+        if (e.list.size() != 3) {
+          throw err("'^' expects exactly two arguments (base and a non-negative integer exponent)", e.index);
+        }
+        MultivariatePolynomial base = parsePolynomial(e.list.get(1));
+        SExpr exponentExpr = e.list.get(2);
+        if (!exponentExpr.isAtom() || exponentExpr.atom.type() != SmtLibLexer.NUMERAL) {
+          throw err("unsupported: '^' with a non-constant integer exponent", e.index);
+        }
+        int exponent = Integer.parseInt(exponentExpr.atom.value());
+        return base.pow(exponent);
+      }
+      case "/" -> {
+        // Only a rational CONSTANT (/ p q) is supported (division by a non-constant polynomial is
+        // not expressible as a polynomial); reject the latter as unsupported.
+        if (e.list.size() != 3) {
+          throw err("'/' expects exactly two arguments", e.index);
+        }
+        Number numerator = tryConstant(e.list.get(1));
+        Number denominator = tryConstant(e.list.get(2));
+        if (numerator == null || denominator == null) {
+          throw err("unsupported: division by a non-constant polynomial", e.index);
+        }
+        return MultivariatePolynomial.constant(numerator.divide(denominator));
+      }
+      default -> throw err("unsupported arithmetic operator '" + head + "'", e.index);
+    }
+  }
+
   // ---- let bindings ---------------------------------------------------------
 
   /**
@@ -960,6 +1141,9 @@ public class SmtLibParser {
    * boolean formula. For equality logics it is always a boolean formula.
    */
   private Object evaluateLetValue(SExpr valueExpr) {
+    if (kind == Kind.NONLINEAR && looksLikeArithmeticTerm(valueExpr)) {
+      return parsePolynomial(valueExpr);
+    }
     if (kind == Kind.ARITHMETIC && looksLikeArithmeticTerm(valueExpr)) {
       return parseLinearTerm(valueExpr);
     }
@@ -984,7 +1168,7 @@ public class SmtLibParser {
         return false;
       }
       Object bound = lookupLet(v);
-      if (bound instanceof LinearTerm) {
+      if (bound instanceof LinearTerm || bound instanceof MultivariatePolynomial) {
         return true;
       }
       if (bound instanceof PropositionalLogicExpression) {
@@ -1007,7 +1191,7 @@ public class SmtLibParser {
       return !"Bool".equals(defineFuns.get(head).returnSort());
     }
     return switch (head) {
-      case "+", "-", "*", "/" -> true;
+      case "+", "-", "*", "/", "^" -> true;
       default -> false;
     };
   }
@@ -1079,7 +1263,9 @@ public class SmtLibParser {
     if (e.isAtom()) {
       Tok t = e.atom;
       if (t.type() == SmtLibLexer.NUMERAL) {
-        return kind == Kind.ARITHMETIC && "QF_LRA".equals(logicName) ? "Real" : "Int";
+        boolean realLogic =
+            kind == Kind.NONLINEAR || (kind == Kind.ARITHMETIC && "QF_LRA".equals(logicName));
+        return realLogic ? "Real" : "Int";
       }
       if (t.type() == SmtLibLexer.DECIMAL) {
         return "Real";
@@ -1092,7 +1278,7 @@ public class SmtLibParser {
       if (bound instanceof PropositionalLogicExpression) {
         return "Bool";
       }
-      if (bound instanceof LinearTerm) {
+      if (bound instanceof LinearTerm || bound instanceof MultivariatePolynomial) {
         return "Real";
       }
       if (defineFuns.containsKey(v)) {
@@ -1109,7 +1295,7 @@ public class SmtLibParser {
           "<=", ">=", "<", ">", "true", "false" -> {
         return "Bool";
       }
-      case "+", "-", "*", "/" -> {
+      case "+", "-", "*", "/", "^" -> {
         return "Real";
       }
       case "ite" -> {

--- a/src/main/java/me/paultristanwagner/satchecking/theory/nonlinear/MultivariatePolynomialConstraint.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/nonlinear/MultivariatePolynomialConstraint.java
@@ -1,6 +1,12 @@
 package me.paultristanwagner.satchecking.theory.nonlinear;
 
 import me.paultristanwagner.satchecking.theory.Constraint;
+import me.paultristanwagner.satchecking.theory.arithmetic.Number;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
 
 public class MultivariatePolynomialConstraint implements Constraint {
 
@@ -101,6 +107,103 @@ public class MultivariatePolynomialConstraint implements Constraint {
 
   public Comparison getComparison() {
     return comparison;
+  }
+
+  /**
+   * The negation of a polynomial constraint over the reals is exact: it keeps the SAME polynomial and
+   * flips the comparison ({@code p < 0} negates to {@code p >= 0}, etc.). This is used by the lazy SMT
+   * loop to obtain the constraint for a literal asserted false, so it MUST be sound.
+   */
+  @Override
+  public boolean isNegatable() {
+    return true;
+  }
+
+  @Override
+  public Constraint negate() {
+    Comparison negated =
+        switch (comparison) {
+          case EQUALS -> Comparison.NOT_EQUALS;
+          case NOT_EQUALS -> Comparison.EQUALS;
+          case LESS_THAN -> Comparison.GREATER_THAN_OR_EQUALS;
+          case GREATER_THAN_OR_EQUALS -> Comparison.LESS_THAN;
+          case GREATER_THAN -> Comparison.LESS_THAN_OR_EQUALS;
+          case LESS_THAN_OR_EQUALS -> Comparison.GREATER_THAN;
+        };
+    return new MultivariatePolynomialConstraint(polynomial, negated);
+  }
+
+  /**
+   * A stable, variable-order-independent canonical form of the polynomial used for {@link #equals}
+   * and {@link #hashCode}. We deliberately do NOT rely on {@link MultivariatePolynomial#equals}/{@link
+   * MultivariatePolynomial#hashCode}: those call a {@code prune()} that mutates the polynomial's
+   * fields, which would make this constraint unsafe as a hash-map / {@code BiMap} key. Instead we
+   * derive the canonical form directly from the (immutable view of the) coefficient map, keying each
+   * monomial by VARIABLE NAME rather than by positional exponent so that two polynomials built with
+   * different internal variable orderings still compare equal.
+   *
+   * <p>Zero coefficients are dropped, so {@code x - x} and {@code 0} share a canonical form.
+   */
+  private String canonicalPolynomial() {
+    if (polynomial == null) {
+      return "null"; // optimization constraints (no comparison); never used as an atom key.
+    }
+
+    List<String> variables = polynomial.variables;
+    // Map each monomial to a sorted "var^exp*..." key -> accumulated coefficient (Number, not String,
+    // so we never round-trip through a possibly-lossy textual form), dropping zero terms.
+    TreeMap<String, Number> monomials = new TreeMap<>();
+    for (Map.Entry<Exponent, Number> entry : polynomial.coefficients.entrySet()) {
+      Number coefficient = entry.getValue();
+      if (coefficient == null || coefficient.isZero()) {
+        continue;
+      }
+      Exponent exponent = entry.getKey();
+      List<Integer> powers = exponent.getValues();
+      TreeMap<String, Integer> byName = new TreeMap<>();
+      for (int i = 0; i < variables.size() && i < powers.size(); i++) {
+        int power = powers.get(i);
+        if (power != 0) {
+          byName.merge(variables.get(i), power, Integer::sum);
+        }
+      }
+      StringBuilder key = new StringBuilder();
+      for (Map.Entry<String, Integer> ve : byName.entrySet()) {
+        if (key.length() > 0) {
+          key.append('*');
+        }
+        key.append(ve.getKey()).append('^').append(ve.getValue());
+      }
+      // Identical monomials (after name-keying) accumulate their coefficients.
+      monomials.merge(key.toString(), coefficient, Number::add);
+    }
+
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<String, Number> m : monomials.entrySet()) {
+      if (m.getValue().isZero()) {
+        continue; // monomials that cancel out
+      }
+      sb.append('[').append(m.getValue()).append(']').append(m.getKey()).append(';');
+    }
+    return sb.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MultivariatePolynomialConstraint that = (MultivariatePolynomialConstraint) o;
+    return comparison == that.comparison
+        && Objects.equals(canonicalPolynomial(), that.canonicalPolynomial());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(comparison, canonicalPolynomial());
   }
 
   @Override

--- a/src/test/java/SmtLibNraTest.java
+++ b/src/test/java/SmtLibNraTest.java
@@ -1,0 +1,180 @@
+import me.paultristanwagner.satchecking.command.impl.SmtLibCommand;
+import me.paultristanwagner.satchecking.command.impl.SmtLibCommand.Verdict;
+import me.paultristanwagner.satchecking.theory.Constraint;
+import me.paultristanwagner.satchecking.theory.nonlinear.MultivariatePolynomial;
+import me.paultristanwagner.satchecking.theory.nonlinear.MultivariatePolynomialConstraint;
+import me.paultristanwagner.satchecking.theory.nonlinear.MultivariatePolynomialConstraint.Comparison;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static me.paultristanwagner.satchecking.theory.arithmetic.Number.number;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the QF_NRA (non-linear real arithmetic) front-end of the SMT-LIB parser, wiring real
+ * polynomial constraints through to the experimental CAD solver, plus the {@link
+ * MultivariatePolynomialConstraint} negation / value-equality contract that makes the atom map
+ * reliable.
+ *
+ * <p>The CAD solver is experimental and may not terminate on harder inputs; every test here uses
+ * only small instances and a generous per-test timeout.
+ *
+ * @author Paul Tristan Wagner <paultristanwagner@gmail.com>
+ */
+public class SmtLibNraTest {
+
+  private static Verdict run(String script) {
+    return SmtLibCommand.runScript(script, false);
+  }
+
+  // ---- hand cases through the full pipeline --------------------------------
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  public void testCircleAndCubicSat() {
+    // x^2 + y^2 = 1 and x^2 + y^3 = 1/2 (README example).
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_NRA)(declare-const x Real)(declare-const y Real)"
+                + "(assert (= (+ (* x x) (* y y)) 1))"
+                + "(assert (= (+ (* x x) (* y y y)) (/ 1 2)))(check-sat)"));
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  public void testThreeProductsUnsat() {
+    // xy>0, yz>0, xz>0 force x,y,z same sign, contradicting x+y+z=0.
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_NRA)(declare-const x Real)(declare-const y Real)(declare-const z Real)"
+                + "(assert (> (* x y) 0))(assert (> (* y z) 0))(assert (> (* x z) 0))"
+                + "(assert (= (+ x y z) 0))(check-sat)"));
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  public void testXSquaredEqualsTwoSat() {
+    assertEquals(
+        Verdict.SAT,
+        run("(set-logic QF_NRA)(declare-const x Real)(assert (= (* x x) 2))(check-sat)"));
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  public void testXSquaredTwoAndThreeUnsat() {
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_NRA)(declare-const x Real)"
+                + "(assert (and (= (* x x) 2) (= (* x x) 3)))(check-sat)"));
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  public void testBooleanStructureWithNegationUnsat() {
+    // x^2 < 0 is impossible and x > 5 contradicts x <= 5, so the disjunction with x<=5 is unsat.
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_NRA)(declare-const x Real)"
+                + "(assert (or (< (* x x) 0) (> x 5)))(assert (<= x 5))(check-sat)"));
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  public void testPowerOperatorSat() {
+    // (^ x 2) should behave like x*x.
+    assertEquals(
+        Verdict.SAT,
+        run("(set-logic QF_NRA)(declare-const x Real)(assert (= (^ x 2) 4))(check-sat)"));
+  }
+
+  @Test
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  public void testNotEqualsNegationSat() {
+    // negated equality: (not (= (* x x) 0)) is x^2 != 0, satisfiable.
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_NRA)(declare-const x Real)"
+                + "(assert (not (= (* x x) 0)))(check-sat)"));
+  }
+
+  // ---- constraint negation / value-equality contract -----------------------
+
+  @Test
+  public void testNegateFlipsComparisonOnSamePolynomial() {
+    MultivariatePolynomial p = MultivariatePolynomial.variable("x");
+    MultivariatePolynomialConstraint lt =
+        MultivariatePolynomialConstraint.multivariatePolynomialConstraint(p, Comparison.LESS_THAN);
+
+    assertTrue(lt.isNegatable());
+    Constraint negated = lt.negate();
+    assertEquals(
+        Comparison.GREATER_THAN_OR_EQUALS,
+        ((MultivariatePolynomialConstraint) negated).getComparison());
+    // The polynomial is unchanged by negation.
+    assertEquals(p, ((MultivariatePolynomialConstraint) negated).getPolynomial());
+  }
+
+  @Test
+  public void testDoubleNegateRoundTrips() {
+    MultivariatePolynomial p =
+        MultivariatePolynomial.variable("x")
+            .multiply(MultivariatePolynomial.variable("x"))
+            .subtract(MultivariatePolynomial.constant(number(2)));
+    for (Comparison c : Comparison.values()) {
+      MultivariatePolynomialConstraint constraint =
+          MultivariatePolynomialConstraint.multivariatePolynomialConstraint(p, c);
+      assertEquals(constraint, constraint.negate().negate(), "round-trip for " + c);
+    }
+  }
+
+  @Test
+  public void testValueEqualityIsVariableOrderIndependent() {
+    MultivariatePolynomial x = MultivariatePolynomial.variable("x");
+    MultivariatePolynomial y = MultivariatePolynomial.variable("y");
+    // x^2 + y^2 - 1 built in two different variable orders.
+    MultivariatePolynomial p1 =
+        x.multiply(x).add(y.multiply(y)).subtract(MultivariatePolynomial.constant(number(1)));
+    MultivariatePolynomial p2 =
+        y.multiply(y).add(x.multiply(x)).subtract(MultivariatePolynomial.constant(number(1)));
+
+    MultivariatePolynomialConstraint c1 =
+        MultivariatePolynomialConstraint.multivariatePolynomialConstraint(p1, Comparison.EQUALS);
+    MultivariatePolynomialConstraint c2 =
+        MultivariatePolynomialConstraint.multivariatePolynomialConstraint(p2, Comparison.EQUALS);
+
+    assertEquals(c1, c2);
+    assertEquals(c1.hashCode(), c2.hashCode());
+
+    // Different comparison must not be equal.
+    MultivariatePolynomialConstraint c3 =
+        MultivariatePolynomialConstraint.multivariatePolynomialConstraint(p1, Comparison.NOT_EQUALS);
+    assertNotEquals(c1, c3);
+  }
+
+  @Test
+  public void testDedupInHashSet() {
+    MultivariatePolynomial x = MultivariatePolynomial.variable("x");
+    MultivariatePolynomialConstraint a =
+        MultivariatePolynomialConstraint.multivariatePolynomialConstraint(
+            x.multiply(x), Comparison.GREATER_THAN);
+    MultivariatePolynomialConstraint b =
+        MultivariatePolynomialConstraint.multivariatePolynomialConstraint(
+            x.multiply(x), Comparison.GREATER_THAN);
+
+    Set<Constraint> set = new HashSet<>();
+    set.add(a);
+    set.add(b);
+    assertEquals(1, set.size());
+  }
+}


### PR DESCRIPTION
## SMT-LIB QF_NRA front-end (non-linear real arithmetic via CAD)

Wires QF_NRA into the SMT-LIB parser so real non-linear benchmarks run through the existing CAD solver.

### Added
- `MultivariatePolynomialConstraint`: `isNegatable()`→true and `negate()` (exact comparison flip on the same polynomial — EQUALS↔NOT_EQUALS, LESS_THAN↔GREATER_THAN_OR_EQUALS, GREATER_THAN↔LESS_THAN_OR_EQUALS), so the lazy loop can assert negated atoms soundly. Value-based `equals`/`hashCode` keyed on a **stable, variable-order-independent canonical form** (deliberately NOT delegating to `MultivariatePolynomial.equals`, which calls a mutating `prune()`) — so the atom BiMap and `negate().negate()` round-trip are reliable.
- `SmtLibParser` QF_NRA path: prefix polynomial terms (`+`, unary/n-ary `-`, **nonlinear** `*`, `(^ t n)` power, numerals/decimals, rational-constant `/`), atoms `<= < >= > = distinct` → `MultivariatePolynomialConstraint(p−q, …)` (no `=`-split needed — `NOT_EQUALS` is native), reusing the existing Tseitin/`TheoryCNF` boolean-structure machinery (+ `let`/`define-fun`/Bool vars). Division by a non-constant polynomial is rejected as unsupported.

### Verification (standalone harness + JUnit; no Maven here)
- Hand cases all correct: x²+y²=1 ∧ x²+y³=½ → sat; (xy>0 ∧ yz>0 ∧ xz>0 ∧ x+y+z=0) → unsat; x²=2 → sat; x²=2∧x²=3 → unsat; boolean-structure+negation (x²<0 ∨ x>5)∧x≤5 → unsat.
- Real SMT-LIB QF_NRA benchmarks: 15 smallest → 15/15 MATCH_SAT; a harder stress sample → 13/15 correct (11 unsat, 2 sat) with **2 SAT timeouts**; an UNSAT-only sample (meti-tarski atan) → **15/15 MATCH_UNSAT**. **0 mismatch, 0 crash** in all runs.
- Full regression green: differential SAT 0/0/0; #10/#14/#20/#36 intact; qflra 20/20, qflia 20/20, Goel unchanged.

### Honest assessment / limitations
The CAD solver is **experimental** (open bugs #11 projection, #12 square-free factorization, possible non-termination). On the sampled benchmarks every terminating verdict was correct and no mismatch/crash surfaced, but **hard SAT instances time out** and the #11/#12 bugs could still produce wrong answers on other inputs — QF_NRA results are best-effort. Unsupported: division by non-constant polynomial; optimization objectives. Advances #33.
