### PR TITLE
Fix build inconsistencies: compiler level 13↔16, JLine version mismatch (#22, #29)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>13</maven.compiler.source>
-        <maven.compiler.target>13</maven.compiler.target>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal-jansi</artifactId>
-            <version>3.23.0</version>
+            <version>3.29.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Aligns `maven.compiler.source/target` to **16** (they were 13 in `<properties>` while the compiler-plugin forced 16; the code uses records/text-blocks/pattern-instanceof — verified compiles at `--release 16`), and pins **jline-terminal-jansi to 3.29.0** to match `jline` (mismatched JLine module versions risk `NoSuchMethodError`). Closes #22, #29.