### PR TITLE
Fix ReadCommand: single-file arg, per-line execution, reader leak (#26)

### DIFF
--- a/src/main/java/me/paultristanwagner/satchecking/command/impl/ReadCommand.java
+++ b/src/main/java/me/paultristanwagner/satchecking/command/impl/ReadCommand.java
@@ -20,29 +20,29 @@ public class ReadCommand extends Command {
 
   @Override
   public boolean execute(String label, String[] args) {
-    if (args.length < 2) {
+    if (args.length < 1) {
       return false;
     }
 
     String fileName = String.join(" ", args);
     File file = new File(fileName);
     if (!file.exists()) {
-      System.out.printf("%sFile '%s' does not exists%s%n", RED, fileName, RESET);
+      System.out.printf("%sFile '%s' does not exist%s%n", RED, fileName, RESET);
       System.out.println();
       return true;
     }
 
-    try {
-      BufferedReader bufferedReader = new BufferedReader(new FileReader(file));
-      StringBuilder builder = new StringBuilder();
+    // Execute each non-blank line as its own command. The previous implementation
+    // concatenated all lines with no separator and ran the result as a single command.
+    try (BufferedReader bufferedReader = new BufferedReader(new FileReader(file))) {
       String line;
       while ((line = bufferedReader.readLine()) != null) {
-        builder.append(line);
+        String command = line.trim();
+        if (command.isEmpty()) {
+          continue;
+        }
+        COMMAND_EXECUTOR.execute(command);
       }
-
-      String input = builder.toString();
-
-      COMMAND_EXECUTOR.execute(input);
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/src/test/java/ReadCommandTest.java
+++ b/src/test/java/ReadCommandTest.java
@@ -1,0 +1,25 @@
+import me.paultristanwagner.satchecking.command.impl.ReadCommand;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ReadCommandTest {
+
+  // Regression for #26: `read <file>` produces args of length 1 (the label is stripped by the
+  // CommandExecutor), so the old `args.length < 2` check rejected every single-file invocation.
+  @Test
+  public void rejectsOnlyWhenNoFileGiven() {
+    ReadCommand command = new ReadCommand();
+    // No file argument -> usage error (returns false). Does not touch the command executor.
+    assertFalse(command.execute("read", new String[0]));
+  }
+
+  @Test
+  public void acceptsAFileArgument() {
+    ReadCommand command = new ReadCommand();
+    // A (non-existent) file argument is accepted as a valid invocation: the command handles it
+    // gracefully and returns true rather than printing the usage error. Avoids the executor.
+    assertTrue(command.execute("read", new String[] {"this-file-does-not-exist-xyz.smt"}));
+  }
+}


### PR DESCRIPTION
`read <file>` was unusable: `args.length < 2` rejected the single-file invocation (the executor strips the label → `args.length==1`); lines were concatenated with no separator and run as one garbled command; the `BufferedReader` was never closed. Now: accepts `<file>`, **executes each non-blank line as its own command**, uses try-with-resources, fixes the `does not exist` grammar. Verified: a 2-line script runs both commands (UNSAT then SAT x=3), blank lines skipped. Adds `ReadCommandTest`. Closes #26.