### PR TITLE
Harden Simplex infeasibility explanation (structural slack tracking, not name-parsing) (#24)

### DIFF
--- a/src/main/java/me/paultristanwagner/satchecking/theory/solver/SimplexFeasibilitySolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/solver/SimplexFeasibilitySolver.java
@@ -25,6 +25,10 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
   private Map<String, DeltaRational> lowerBounds;
   private Map<String, DeltaRational> upperBounds;
 
+  // Maps each slack variable name to the index of the constraint it represents. Used to build
+  // infeasibility explanations structurally rather than by parsing variable names.
+  private Map<String, Integer> slackConstraintIndices;
+
   private final List<LinearConstraint> constraints = new ArrayList<>();
 
   @Override
@@ -36,6 +40,7 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
     values = null;
     lowerBounds = null;
     upperBounds = null;
+    slackConstraintIndices = null;
     rows = 0;
     columns = 0;
   }
@@ -72,11 +77,13 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
 
     // Initialize slack variables, tableau and constraints
     basicVariables = new ArrayList<>();
+    slackConstraintIndices = new HashMap<>();
     tableau = new Number[constraints.size()][variableSet.size()];
     for (int i = 0; i < constraints.size(); i++) {
       String slackName = "s" + i;
       LinearConstraint constraint = constraints.get(i);
       basicVariables.add(slackName);
+      slackConstraintIndices.put(slackName, i);
 
       for (int j = 0; j < variableSet.size(); j++) {
         String variable = variables.get(j);
@@ -214,20 +221,24 @@ public class SimplexFeasibilitySolver implements TheorySolver<LinearConstraint> 
   private Set<LinearConstraint> calculateExplanation(Violation violation) {
     Set<LinearConstraint> explanation = new HashSet<>();
 
-    int constraintIndex = Integer.parseInt(violation.variable().split("s")[1]);
-    LinearConstraint constraint = constraints.get(constraintIndex);
+    // The violating variable is a slack; add the constraint it represents.
+    Integer violatingIndex = slackConstraintIndices.get(violation.variable());
+    if (violatingIndex != null) {
+      explanation.add(constraints.get(violatingIndex));
+    }
 
-    explanation.add(constraint);
-
+    // Add the constraints of every slack with a non-zero coefficient in the violating row.
+    // Original (non-slack) variables represent no constraint, so they are skipped. Previously
+    // this parsed the variable name (split("s")), which crashed on original variables or names
+    // containing 's', and after pivots when a non-basic was an original variable.
     int basicIndex = basicVariables.indexOf(violation.variable());
     for (int j = 0; j < columns; j++) {
       Number a = tableau[basicIndex][j];
       if (a.isNonZero()) {
-        String variable = nonBasicVariables.get(j);
-        constraintIndex = Integer.parseInt(variable.split("s")[1]);
-        constraint = constraints.get(constraintIndex);
-
-        explanation.add(constraint);
+        Integer constraintIndex = slackConstraintIndices.get(nonBasicVariables.get(j));
+        if (constraintIndex != null) {
+          explanation.add(constraints.get(constraintIndex));
+        }
       }
     }
 

--- a/src/test/java/SimplexExplanationTest.java
+++ b/src/test/java/SimplexExplanationTest.java
@@ -1,0 +1,38 @@
+import me.paultristanwagner.satchecking.parse.LinearConstraintParser;
+import me.paultristanwagner.satchecking.theory.SimplexResult;
+import me.paultristanwagner.satchecking.theory.solver.SimplexFeasibilitySolver;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class SimplexExplanationTest {
+
+  private static SimplexResult solve(String... constraints) {
+    SimplexFeasibilitySolver solver = new SimplexFeasibilitySolver();
+    LinearConstraintParser parser = new LinearConstraintParser();
+    for (String c : constraints) {
+      solver.addConstraint(parser.parse(c));
+    }
+    return solver.solve();
+  }
+
+  /**
+   * Hardening for #24: infeasibility-explanation generation previously parsed slack indices out of
+   * variable names (`split("s")`), which is unsafe for variables containing or lacking 's'. These
+   * infeasible instances must report infeasible without throwing, regardless of variable names.
+   */
+  @Test
+  public void infeasibleWithVariableNamedS() {
+    assertFalse(solve("s<=-1", "s>=1").isFeasible());
+  }
+
+  @Test
+  public void infeasibleWithVariableContainingS() {
+    assertFalse(solve("cost<=-10", "cost>=10").isFeasible());
+  }
+
+  @Test
+  public void infeasibleWithPlainVariables() {
+    assertFalse(solve("x+y<=-10", "x+y>=10").isFeasible());
+  }
+}


### PR DESCRIPTION
`calculateExplanation` parsed slack indices from variable names (`split("s")[1]`), which is unsafe for any non-slack variable in the conflict row (`x`, `cost`, or a user var named `sN`). Replaced with a `slackName -> constraintIndex` map; non-slack variables are skipped. **Honest note:** I could not reproduce an actual crash on sampled infeasible inputs — the conflict row is typically expressed via slacks — so this is robustness hardening, not a confirmed-crash fix (#24 reclassified). Regression green (differential 0/0/0; qflra/qflia UNSAT explanation path 15/15). Adds `SimplexExplanationTest`. Addresses #24.