### PR TITLE
Fix BitVector(int,length) truncating values wider than 8 bits (#16)

### DIFF
--- a/src/main/java/me/paultristanwagner/satchecking/theory/bitvector/BitVector.java
+++ b/src/main/java/me/paultristanwagner/satchecking/theory/bitvector/BitVector.java
@@ -23,7 +23,9 @@ public class BitVector {
     this.length = length;
     this.bits = new boolean[length];
 
-    for (int i = 0; i < Math.min(DEFAULT_BIT_VECTOR_LENGTH, 32); i++) {
+    // Fill all `length` bits (was Math.min(DEFAULT_BIT_VECTOR_LENGTH, 32), which capped at 8 and
+    // silently truncated any value wider than 8 bits). Matches the (long, int) constructor.
+    for (int i = 0; i < length; i++) {
       bits[i] = (value & (1L << i)) != 0;
     }
   }

--- a/src/test/java/BitVectorWidthTest.java
+++ b/src/test/java/BitVectorWidthTest.java
@@ -1,0 +1,32 @@
+import me.paultristanwagner.satchecking.theory.bitvector.BitVector;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BitVectorWidthTest {
+
+  // Regression for #16: BitVector(int, length) used to fill only min(8, 32) bits, truncating any
+  // value wider than 8 bits regardless of the requested length.
+  @Test
+  public void valuesWiderThanEightBitsAreNotTruncated() {
+    assertEquals(300, new BitVector(300, 16).asInt(), "300 must fit in 16 bits");
+    assertEquals(1000, new BitVector(1000, 16).asInt());
+    assertEquals(70000, new BitVector(70000, 32).asInt());
+  }
+
+  @Test
+  public void smallValuesStillWork() {
+    assertEquals(5, new BitVector(5, 16).asInt());
+    assertEquals(255, new BitVector(255, 8).asInt());
+  }
+
+  @Test
+  public void intAndLongConstructorsAgree() {
+    for (int v : new int[] {0, 1, 7, 200, 300, 65535, 70000}) {
+      assertEquals(
+          new BitVector((long) v, 32).asInt(),
+          new BitVector(v, 32).asInt(),
+          "int and long constructors must agree for value " + v);
+    }
+  }
+}


### PR DESCRIPTION
`BitVector(int value, int length)` looped over `Math.min(DEFAULT_BIT_VECTOR_LENGTH, 32)` = **8** bits regardless of `length`, silently truncating wider values: `new BitVector(300,16).asInt()` returned **44**. Loop over `length` (matching the `(long,int)` constructor). Verified RED→GREEN (300→44/1000→232/70000→112 were wrong, now correct; int and long constructors agree). Used by `BitVectorConstant.constant` and the custom BV parser. Regression green. Adds `BitVectorWidthTest`. Closes #16.