### PR TITLE
Lexer: cache compiled Patterns + hoist substring out of the loop (#21)

### DIFF
--- a/src/main/java/me/paultristanwagner/satchecking/parse/Lexer.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/Lexer.java
@@ -48,11 +48,12 @@ public abstract class Lexer {
       return null;
     }
 
-    for (TokenType tokenType : tokenTypes) {
-      String regex = tokenType.getRegex();
-      String remaining = input.substring(cursor);
+    // The remainder is the same for every token type; compute it once. Each token type carries a
+    // precompiled Pattern (previously this recompiled the regex for every type on every token).
+    String remaining = input.substring(cursor);
 
-      Matcher matcher = Pattern.compile(regex).matcher(remaining);
+    for (TokenType tokenType : tokenTypes) {
+      Matcher matcher = tokenType.getPattern().matcher(remaining);
 
       if (!matcher.find()) {
         continue;

--- a/src/main/java/me/paultristanwagner/satchecking/parse/TokenType.java
+++ b/src/main/java/me/paultristanwagner/satchecking/parse/TokenType.java
@@ -1,5 +1,7 @@
 package me.paultristanwagner.satchecking.parse;
 
+import java.util.regex.Pattern;
+
 public class TokenType {
 
   static final TokenType IDENTIFIER = TokenType.of("identifier", "^([a-zA-Z][a-zA-Z0-9_]*|_[a-zA-Z0-9_]+)");
@@ -42,10 +44,13 @@ public class TokenType {
 
   private final String name;
   private final String regex;
+  // Compiled once at construction; the lexer used to recompile the regex on every token.
+  private final Pattern pattern;
 
   private TokenType(String name, String regex) {
     this.name = name;
     this.regex = regex;
+    this.pattern = Pattern.compile(regex);
   }
 
   public static TokenType of(String name, String regex) {
@@ -58,5 +63,9 @@ public class TokenType {
 
   public String getRegex() {
     return regex;
+  }
+
+  public Pattern getPattern() {
+    return pattern;
   }
 }


### PR DESCRIPTION
`Lexer.nextToken` recompiled every token type's regex (`Pattern.compile`) and recomputed `input.substring(cursor)` for **every token type on every token** — O(n²·types). Now each `TokenType` compiles its `Pattern` once at construction, and the remaining substring is computed once per token. Speeds up all lexing (now heavily used for SMT-LIB/DIMACS benchmark parsing). **Pure performance change, no semantics** — full regression identical: differential SAT 0/0/0, and the strict/QF_LRA/LIA/NRA/EUF/BV + DIMACS suites are byte-for-byte unchanged vs the pre-change build. Addresses the lexer part of #21.