### PR TITLE
Lazy loop: theory conflict lemmas participate in BCP (#43)

### DIFF
--- a/src/main/java/me/paultristanwagner/satchecking/sat/solver/DPLLCDCLSolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/sat/solver/DPLLCDCLSolver.java
@@ -259,6 +259,39 @@ public class DPLLCDCLSolver implements SATSolver {
     return resolveConflict();
   }
 
+  /**
+   * Learns a theory conflict lemma so that it participates in watched-literal BCP from now on
+   * (issue #43), WITHOUT driving an immediate conflict-analysis/backjump from the present state.
+   *
+   * <p>This is the counterpart of {@link #excludeClause(Clause)} for the {@code nextModel()}-based
+   * full-lazy enumeration loop: there the previous complete model is always blocked by the solver
+   * itself (via {@code assignment.not()}), which is guaranteed to be an asserting conflict clause
+   * and therefore safe to feed into {@link #resolveConflict()}. A theory lemma derived from a
+   * complete model, by contrast, may have all of its literals falsified across several decision
+   * levels with none at the current level, which is NOT a well-formed input for the 1-UIP analysis
+   * in {@code resolveConflict}. So we do not run conflict analysis on it; we only register it.
+   *
+   * <p>To preserve the 2-watched-literal invariant we (re)select the two watched literals using the
+   * standard rule against the CURRENT assignment and, if the clause is already unit or conflicting,
+   * enqueue/flag it so the very next {@code bcp()} (inside the next {@code nextModel()} →
+   * {@code check()}) acts on it. {@code nextModel()} clears the unit queue before blocking the old
+   * model, so a unit enqueued here for the soon-to-be-undone complete model is harmless; the lemma's
+   * watches persist and fire again once its literals are reassigned during the next search.
+   */
+  public void learnTheoryLemma(Clause clause) {
+    learnClause(clause);
+
+    WatchedLiteralPair wlp = watchedLiteralsMap.get(clause);
+    if (wlp.isConflicting(assignment)) {
+      conflictingClause = clause;
+    } else {
+      Literal unitLiteral = wlp.getUnitLiteral(assignment);
+      if (unitLiteral != null) {
+        unitClauses.add(Pair.of(clause, unitLiteral));
+      }
+    }
+  }
+
   private void learnClause(Clause clause) {
     cnf.learnClause(clause);
 

--- a/src/main/java/me/paultristanwagner/satchecking/smt/solver/FullLazySMTSolver.java
+++ b/src/main/java/me/paultristanwagner/satchecking/smt/solver/FullLazySMTSolver.java
@@ -3,6 +3,7 @@ package me.paultristanwagner.satchecking.smt.solver;
 import me.paultristanwagner.satchecking.sat.Assignment;
 import me.paultristanwagner.satchecking.sat.Clause;
 import me.paultristanwagner.satchecking.sat.Literal;
+import me.paultristanwagner.satchecking.sat.solver.DPLLCDCLSolver;
 import me.paultristanwagner.satchecking.smt.SMTResult;
 import me.paultristanwagner.satchecking.smt.VariableAssignment;
 import me.paultristanwagner.satchecking.theory.Constraint;
@@ -21,9 +22,25 @@ public class FullLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
   public SMTResult<C> solve() {
     satSolver.load(cnf.getBooleanStructure());
 
+    // Theory conflict lemmas are learned WITH watched-literal setup so that they participate in the
+    // SAT solver's conflict-driven propagation (issue #43). Previously the lemma was appended via
+    // CNF.learnClause, which adds it to the clause list but does NOT initialize watched literals, so
+    // it was inert for BCP and the enumeration relied solely on nextModel()'s per-model blocking
+    // (worst-case 2^n iterations). Routing the lemma through DPLLCDCLSolver.learnTheoryLemma makes
+    // it prune the remaining search, while the complete model itself is still blocked by
+    // nextModel() (via assignment.not()), so termination is unchanged.
+    //
+    // We keep the robust nextModel()-based enumeration rather than the excludeClause() path used by
+    // LessLazySMTSolver: a theory lemma derived from a COMPLETE model can have all of its literals
+    // falsified across several decision levels with none at the current level, which is not a
+    // well-formed input for the 1-UIP conflict analysis that excludeClause() runs. nextModel()'s
+    // own blocking clause is always asserting and therefore safe.
+    DPLLCDCLSolver cdclSolver =
+        satSolver instanceof DPLLCDCLSolver ? (DPLLCDCLSolver) satSolver : null;
+
     // Tracking for the optimization case: we cannot return on the first theory-satisfiable
     // Boolean model, because a different Boolean model may yield a better optimum. We therefore
-    // enumerate all theory-consistent Boolean models and keep the best optimum seen.
+    // enumerate all theory-consistent Boolean models and keep the best optimum seen (issue #20).
     boolean objectivePresent = false;
     boolean maximizing = false;
     boolean foundOptimizationSolution = false;
@@ -145,7 +162,15 @@ public class FullLazySMTSolver<C extends Constraint> extends SMTSolver<C> {
       // current model is still excluded by nextModel()'s built-in blocking, so termination holds.
       if (!literals.isEmpty()) {
         Clause clause = new Clause(literals);
-        cnf.getBooleanStructure().learnClause(clause);
+        if (cdclSolver != null) {
+          // Learn the lemma WITH watched literals so it participates in BCP and prunes the search.
+          cdclSolver.learnTheoryLemma(clause);
+        } else {
+          // Fallback for non-CDCL SAT backends: keep the original inert-learning behavior. The
+          // clause is still recorded for any solver that re-derives watches on load, and the model
+          // is excluded by nextModel()'s blocking.
+          cnf.getBooleanStructure().learnClause(clause);
+        }
       }
     }
 

--- a/src/test/java/FullLazyWatchedLemmaTest.java
+++ b/src/test/java/FullLazyWatchedLemmaTest.java
@@ -1,0 +1,93 @@
+import me.paultristanwagner.satchecking.command.impl.SmtLibCommand;
+import me.paultristanwagner.satchecking.command.impl.SmtLibCommand.Verdict;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for issue #43: theory conflict lemmas produced by {@link
+ * me.paultristanwagner.satchecking.smt.solver.FullLazySMTSolver} are now learned WITH watched
+ * literals (via {@code DPLLCDCLSolver.learnTheoryLemma}) so they participate in conflict-driven
+ * propagation and prune the SAT search, instead of being appended inertly via {@code
+ * CNF.learnClause}.
+ *
+ * <p>These cases all run through the full-lazy logics (QF_UF/QF_EQUF, QF_LRA, QF_LIA, QF_NRA) and
+ * assert that verdicts are unchanged. The {@code eq_diamond} family is exactly the class of QF_UF
+ * instances whose pruning depends on the lemmas being active in BCP: with inert lemmas these need
+ * exponentially many model-blocking iterations; with watched lemmas they terminate quickly. The
+ * encoded instance below is small enough to solve either way, but verifies the lemma path stays
+ * sound on a structurally diamond-shaped problem.
+ */
+public class FullLazyWatchedLemmaTest {
+
+  private static Verdict run(String script) {
+    return SmtLibCommand.runScript(script, false);
+  }
+
+  @Test
+  public void testQfUfCongruenceUnsat() {
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_UF)(declare-sort U 0)(declare-const a U)(declare-const b U)"
+                + "(declare-fun f (U) U)(assert (= a b))(assert (not (= (f a) (f b))))(check-sat)"));
+  }
+
+  @Test
+  public void testQfLraDisjunctionConflictUnsat() {
+    // (x<0 | x>0) & x=0 : every complete Boolean model conflicts in the theory, exercising the
+    // lemma-learning path; result must be unsat.
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_LRA)(declare-const x Real)(assert (or (< x 0) (> x 0)))"
+                + "(assert (= x 0))(check-sat)"));
+  }
+
+  @Test
+  public void testQfLraSat() {
+    assertEquals(
+        Verdict.SAT,
+        run(
+            "(set-logic QF_LRA)(declare-const x Real)(assert (or (<= x 5) (>= x 5)))(check-sat)"));
+  }
+
+  @Test
+  public void testQfLiaEmptyIntervalUnsat() {
+    assertEquals(
+        Verdict.UNSAT,
+        run("(set-logic QF_LIA)(declare-const x Int)(assert (and (> x 0) (< x 1)))(check-sat)"));
+  }
+
+  @Test
+  public void testQfNraSat() {
+    assertEquals(
+        Verdict.SAT,
+        run("(set-logic QF_NRA)(declare-const x Real)(assert (= (* x x) 2))(check-sat)"));
+  }
+
+  @Test
+  public void testQfNraConflictUnsat() {
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_NRA)(declare-const x Real)"
+                + "(assert (and (= (* x x) 2) (= (* x x) 3)))(check-sat)"));
+  }
+
+  @Test
+  public void testEqDiamondShapedUnsat() {
+    // A small "diamond": (a=b | a=c) & (b=d | c=d) & a=d ... combined with a forced inequality so
+    // that the conflict lemmas must prune the alternative paths. This is the QF_UF eq_diamond
+    // structure in miniature; the verdict must be unsat.
+    assertEquals(
+        Verdict.UNSAT,
+        run(
+            "(set-logic QF_UF)(declare-sort U 0)"
+                + "(declare-const a U)(declare-const b U)(declare-const c U)(declare-const d U)"
+                + "(assert (or (= a b) (= a c)))"
+                + "(assert (or (= b d) (= c d)))"
+                + "(assert (= a b))(assert (= b d))"
+                + "(assert (not (= a d)))(check-sat)"));
+  }
+}


### PR DESCRIPTION
## Make FullLazy theory conflict lemmas participate in BCP (#43)

`FullLazySMTSolver` enumerated complete Boolean models and added blocking clauses via `CNF.learnClause` — which records the clause but **does not set up watched literals**, so lemmas were *inert* for BCP and pruning relied solely on `nextModel()`'s per-model `assignment.not()` blocking (worst-case 2ⁿ iterations). Real `eq_diamond` (QF_UF) instances timed out as a result.

### Change
New `DPLLCDCLSolver.learnTheoryLemma(Clause)`: registers the lemma **with watched-literal setup** (so it prunes future search via conflict-driven propagation) but does **not** run 1-UIP conflict analysis on it. `FullLazySMTSolver` routes lemmas through this method (CDCL backend) and keeps the inert fallback for non-CDCL backends.

**Why not reuse `LessLazy`'s `excludeClause`:** a lemma derived from a *complete* model can have all literals falsified across several decision levels with none at the current level — not a well-formed input for 1-UIP (`Clause.isAsserting` needs exactly one current-level literal); it crashes. Keeping `nextModel()`'s enumeration is safe because its own blocking clause (`assignment.not()`) is always asserting, and `nextModel()` clears `unitClauses`/overwrites `conflictingClause` before acting — so the only lasting effect of `learnTheoryLemma` is the lemma's watches. Termination unchanged (≤ 2ⁿ); the watched lemma just prunes more.

### Verification (independently re-run — strict gate, all spotless)
- Differential SAT: 3000 random CNFs, **0 mismatches / 0 invalid / 0 crashes** (SAT core intact).
- Per-theory verdicts (QF_UF/LRA/LIA/NRA) correct; **#20 objective preserved** (`(x<=100|x<=5)&max(x)` → x=100).
- Real benchmark UNSAT lemma-path gates: qflra_unsat 30/30, qflia_unsat 29/29, qfnra_unsat 15/15 — **0 mismatch**.
- **eq_diamond (QF_UF, 30 smallest, 10s): 6 → 10 solved, 24 → 20 timeouts, 0 mismatch.** Strict, sound improvement; no verdict changes anywhere.

Modest at 10s (eq_diamond grows fast; large ones still time out) but a correct, sound step toward DPLL(T)-style learning. Closes the contained part of #43. Adds `FullLazyWatchedLemmaTest`.
