### PR TITLE
Interactive REPL for satcheck-smt

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9,6 +9,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
+name = "memchr"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,10 +162,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "satcheck-core"
@@ -77,6 +236,7 @@ name = "satcheck-smt"
 version = "0.1.0"
 dependencies = [
  "rustc-hash",
+ "rustyline",
  "satcheck-core",
  "satcheck-sat",
  "satcheck-term",
@@ -105,3 +265,118 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,6 +17,7 @@ num-rational = "0.4"
 num-traits = "0.2"
 rustc-hash = "2"
 smallvec = "1"
+rustyline = "14"
 
 # Tuned for the solver hot loops. `panic = "abort"` is intentionally left off so the
 # default `cargo test`/`cargo bench` harnesses stay frictionless; add it to the eventual

--- a/rust/smt/Cargo.toml
+++ b/rust/smt/Cargo.toml
@@ -10,3 +10,4 @@ satcheck-term.workspace = true
 satcheck-sat.workspace = true
 satcheck-theory.workspace = true
 rustc-hash.workspace = true
+rustyline.workspace = true

--- a/rust/smt/src/bin/satcheck-smt.rs
+++ b/rust/smt/src/bin/satcheck-smt.rs
@@ -1,33 +1,48 @@
-//! Headless SMT-LIB front-end for QF_UF/QF_EQ: reads a script from a file (or stdin) and prints
-//! one `sat`/`unsat` line per `(check-sat)`.
+//! SMT-LIB front-end for QF_UF/QF_EQ.
 //!
-//! Usage: `satcheck-smt <file.smt2>` or `satcheck-smt < file.smt2`.
+//! Modes:
+//! - `satcheck-smt <file.smt2>` — run a script file, print one `sat`/`unsat` per `(check-sat)`.
+//! - `satcheck-smt -` or piped stdin — same, reading the script from stdin.
+//! - `satcheck-smt` on a terminal — an interactive REPL (line editing + history) that keeps the
+//!   declaration/assertion state across commands and prints each verdict as it is entered.
 
-use std::io::Read;
+use std::io::{IsTerminal, Read};
 use std::process::ExitCode;
 
+use rustyline::error::ReadlineError;
+use rustyline::DefaultEditor;
 use satcheck_smt::script::Script;
+use satcheck_smt::sexp::{parse_script, Sexp};
 
 fn main() -> ExitCode {
-    let args: Vec<String> = std::env::args().collect();
-    let input = match args.get(1) {
-        Some(path) if path != "-" => match std::fs::read_to_string(path) {
-            Ok(s) => s,
+    let arg = std::env::args().nth(1);
+    match arg.as_deref() {
+        Some("-") => batch(read_stdin()),
+        Some(path) => match std::fs::read_to_string(path) {
+            Ok(s) => batch(s),
             Err(e) => {
                 eprintln!("error: cannot read {path}: {e}");
-                return ExitCode::FAILURE;
+                ExitCode::FAILURE
             }
         },
-        _ => {
-            let mut s = String::new();
-            if let Err(e) = std::io::stdin().read_to_string(&mut s) {
-                eprintln!("error: cannot read stdin: {e}");
-                return ExitCode::FAILURE;
+        None => {
+            if std::io::stdin().is_terminal() {
+                repl()
+            } else {
+                batch(read_stdin())
             }
-            s
         }
-    };
+    }
+}
 
+fn read_stdin() -> String {
+    let mut s = String::new();
+    let _ = std::io::stdin().read_to_string(&mut s);
+    s
+}
+
+/// Non-interactive: parse and run the whole script, print a verdict per `(check-sat)`.
+fn batch(input: String) -> ExitCode {
     match Script::run(&input) {
         Ok(script) => {
             for r in &script.results {
@@ -40,4 +55,157 @@ fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+fn repl() -> ExitCode {
+    let mut rl = match DefaultEditor::new() {
+        Ok(rl) => rl,
+        Err(e) => {
+            eprintln!("error: cannot start REPL: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let history = history_path();
+    if let Some(h) = &history {
+        let _ = rl.load_history(h);
+    }
+
+    println!("satcheck-smt — interactive QF_UF/QF_EQ solver");
+    println!("Enter SMT-LIB commands; `(check-sat)` prints a verdict. Ctrl-D or `(exit)` to quit.");
+
+    let mut script = Script::new();
+    let mut buf = String::new();
+    loop {
+        let prompt = if buf.trim().is_empty() {
+            format!("{}> ", script.logic().unwrap_or("smt"))
+        } else {
+            "   ...> ".to_string()
+        };
+        match rl.readline(&prompt) {
+            Ok(line) => {
+                if !line.trim().is_empty() {
+                    let _ = rl.add_history_entry(line.as_str());
+                }
+                buf.push_str(&line);
+                buf.push('\n');
+                // Execute every complete top-level form; keep any incomplete tail buffered.
+                let n = complete_len(&buf);
+                if n == 0 {
+                    continue;
+                }
+                let ready = buf[..n].to_string();
+                buf.drain(..n);
+                if run_forms(&ready, &mut script) {
+                    break;
+                }
+            }
+            Err(ReadlineError::Interrupted) => {
+                // Ctrl-C: abandon the half-typed form.
+                buf.clear();
+            }
+            Err(ReadlineError::Eof) => break,
+            Err(e) => {
+                eprintln!("error: {e}");
+                break;
+            }
+        }
+    }
+
+    if let Some(h) = &history {
+        let _ = rl.save_history(h);
+    }
+    ExitCode::SUCCESS
+}
+
+/// Parse and run the complete forms in `src`; print verdicts. Returns true on `(exit)`.
+fn run_forms(src: &str, script: &mut Script) -> bool {
+    let cmds = match parse_script(src) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return false;
+        }
+    };
+    for cmd in &cmds {
+        let head = cmd
+            .as_list()
+            .and_then(|l| l.first())
+            .and_then(Sexp::as_atom);
+        if head == Some("exit") {
+            return true;
+        }
+        match script.exec(cmd) {
+            Ok(Some(r)) => {
+                let mut out = r.answer.as_str().to_string();
+                if let Some(exp) = r.expected {
+                    if exp != r.answer {
+                        out.push_str(&format!("   (!! :status said {})", exp.as_str()));
+                    }
+                }
+                println!("{out}");
+            }
+            Ok(None) => {}
+            Err(e) => eprintln!("error: {e}"),
+        }
+    }
+    false
+}
+
+/// Byte length of the longest prefix of `buf` made up of complete top-level s-expressions (paren
+/// depth back to 0), respecting `;` comments, `|quoted|` symbols, and `"strings"`.
+fn complete_len(buf: &str) -> usize {
+    let b = buf.as_bytes();
+    let mut i = 0;
+    let mut depth = 0i32;
+    let mut cut = 0;
+    while i < b.len() {
+        match b[i] {
+            b';' => {
+                while i < b.len() && b[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'|' => {
+                i += 1;
+                while i < b.len() && b[i] != b'|' {
+                    i += 1;
+                }
+                if i < b.len() {
+                    i += 1; // closing '|'
+                }
+            }
+            b'"' => {
+                i += 1;
+                while i < b.len() {
+                    if b[i] == b'"' {
+                        if i + 1 < b.len() && b[i + 1] == b'"' {
+                            i += 2; // escaped quote
+                            continue;
+                        }
+                        i += 1; // closing quote
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            b'(' => {
+                depth += 1;
+                i += 1;
+            }
+            b')' => {
+                i += 1;
+                depth -= 1;
+                if depth <= 0 {
+                    depth = 0;
+                    cut = i;
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    cut
+}
+
+fn history_path() -> Option<std::path::PathBuf> {
+    std::env::var_os("HOME").map(|h| std::path::PathBuf::from(h).join(".satcheck_smt_history"))
 }

--- a/rust/smt/src/script.rs
+++ b/rust/smt/src/script.rs
@@ -50,6 +50,7 @@ pub struct Script {
     asserts: Vec<Sexp>,
     frames: Vec<Frame>,
     expected: Option<Answer>,
+    logic: Option<String>,
     pub results: Vec<CheckResult>,
 }
 
@@ -69,6 +70,7 @@ impl Script {
                 decls: Vec::new(),
             }],
             expected: None,
+            logic: None,
             results: Vec::new(),
         }
     }
@@ -81,6 +83,19 @@ impl Script {
             script.command(cmd)?;
         }
         Ok(script)
+    }
+
+    /// Run a single command, returning the new [`CheckResult`] if it was a `(check-sat)`. Used by
+    /// the interactive REPL to surface verdicts as soon as each command is entered.
+    pub fn exec(&mut self, cmd: &Sexp) -> Result<Option<CheckResult>, String> {
+        let before = self.results.len();
+        self.command(cmd)?;
+        Ok((self.results.len() > before).then(|| self.results.last().unwrap().clone()))
+    }
+
+    /// The logic set via `(set-logic …)`, if any (for the REPL prompt).
+    pub fn logic(&self) -> Option<&str> {
+        self.logic.as_deref()
     }
 
     fn command(&mut self, cmd: &Sexp) -> Result<(), String> {
@@ -109,8 +124,13 @@ impl Script {
                 self.set_info(&list[1..]);
                 Ok(())
             }
-            "set-logic" | "set-option" | "get-model" | "get-info" | "get-value" | "echo"
-            | "reset" | "exit" => Ok(()),
+            "set-logic" => {
+                self.logic = list.get(1).and_then(Sexp::as_atom).map(str::to_string);
+                Ok(())
+            }
+            "set-option" | "get-model" | "get-info" | "get-value" | "echo" | "reset" | "exit" => {
+                Ok(())
+            }
             other => Err(format!("unsupported command '{other}'")),
         }
     }
@@ -658,6 +678,29 @@ mod tests {
             (assert (distinct p q))
             (check-sat)";
         assert_eq!(answers(s), vec![Answer::Unsat]);
+    }
+
+    #[test]
+    fn incremental_exec_surfaces_results() {
+        // Mirrors how the REPL drives the solver: feed commands one at a time and observe the
+        // verdict returned by the (check-sat) command itself.
+        let mut s = Script::new();
+        for src in [
+            "(set-logic QF_UF)",
+            "(declare-sort U 0)",
+            "(declare-fun a () U)",
+            "(declare-fun b () U)",
+            "(assert (= a b))",
+        ] {
+            let cmd = &crate::sexp::parse_script(src).unwrap()[0];
+            assert!(s.exec(cmd).unwrap().is_none());
+        }
+        assert_eq!(s.logic(), Some("QF_UF"));
+        let check = &crate::sexp::parse_script("(check-sat)").unwrap()[0];
+        assert_eq!(s.exec(check).unwrap().unwrap().answer, Answer::Sat);
+        let neg = &crate::sexp::parse_script("(assert (not (= a b)))").unwrap()[0];
+        assert!(s.exec(neg).unwrap().is_none());
+        assert_eq!(s.exec(check).unwrap().unwrap().answer, Answer::Unsat);
     }
 
     #[test]


### PR DESCRIPTION
Adds an interactive REPL to the `satcheck-smt` front-end (the M6 REPL item, brought forward).

## Behaviour
- `satcheck-smt` with **no file arg on a terminal** → REPL with line editing + persistent history (`~/.satcheck_smt_history`, via `rustyline`).
- Keeps declaration/assertion state across commands; the prompt reflects the active logic (`smt>` → `QF_UF>`).
- **Multi-line forms**: shows a `...>` continuation prompt until parentheses balance, then runs.
- Prints each `(check-sat)` verdict live; flags a verdict that disagrees with an in-scope `:status`.
- Exits on `(exit)` or Ctrl-D; Ctrl-C abandons the half-typed form.
- **Unchanged:** a file argument or piped stdin still runs in batch mode (one verdict per `(check-sat)`).

## Example
```
$ satcheck-smt
QF_UF> (declare-sort U 0)
QF_UF> (declare-fun a () U)(declare-fun b () U)(declare-fun f (U) U)
QF_UF> (assert (= a b))
QF_UF> (assert (not (= (f a)
   ...>               (f b))))
QF_UF> (check-sat)
unsat
```

## Internals
- `Script::exec(&mut self, &Sexp)` runs one command and returns the new `CheckResult` if it was a `check-sat`; `Script::logic()` for the prompt.
- Buffer splitter respects `;` comments, `|quoted|` symbols, and `"strings"` when deciding form completeness.
- 33 tests green (added an incremental-`exec` test mirroring REPL usage); fmt clean.